### PR TITLE
Lfm update

### DIFF
--- a/bots.q
+++ b/bots.q
@@ -1,23 +1,23 @@
 labels,:("\\ne";"\\ml";"\\bc";"\\df")!("news";"music";"bitcoin";"define");
 
-.lfm.enabled:1b;
-
 news:{[x;y;z]rc[;y;0]"\033[GGetting news";neg[wh](`getheadline;uct string z);}
 defn:{[x;y;z] neg[wh](`dictlkup;trim "c"$3_x);}
 mulo:{[x;y;z]
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   msg:trim"c"$3_x;                                                                              / get user input
-  if[not[.lfm.enabled]or()~key`:lfm_key;:rc[;y;0]"\033[Gmusic lookup not enabled"];             / return error if unenabled
+  if[()~key`:lfm_key;:rc[;y;0]"\033[Gmusic lookup not enabled"];                                / return error if unenabled
   if[0=count msg;                                                                               / return help message if no input is provided
     :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n* enter a username to attempt now playing lookup\n  users:",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]],"\n* enter 'user=<USERNAME>' to enter or update your own lastfm username\n* unset username by entering 'user='"
   ];
   if[msg like"user=*";                                                                          / update username for current user
-    `:lfm_cache set $[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
+    `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
     :rc[;y;0]"\033[GUpdated username";
   ];
-  if[not(`$msg)in key .lfm.cache;:rc[;y;0]"\033[Guser not available"];                          / return error if requested user is unavailable
+  msg:@[;`filter`period;lower]{(count[x]#`name`filter`period)!x}"&"vs msg;                      / split message parameters
+  `msg2 set msg;
+  if[not(`$msg`name)in key .lfm.cache;:rc[;y;0]"\033[Guser not available"];                     / return error if requested user is unavailable
   rc[;y;0]"\033[GSending Request";
-  neg[wh](`.lfm.nowPlaying;trim uct string z;.lfm.cache`$msg;trim ucn[`$msg;msg]);              / send request to worker process
+  neg[wh](`.lfm.nowPlaying;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]);   / send request to worker process
  };
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];

--- a/bots.q
+++ b/bots.q
@@ -7,7 +7,11 @@ mulo:{[x;y;z]
   msg:trim"c"$3_x;                                                                              / get user input
   if[()~key`:lfm_key;:rc[;y;0]"\033[Gmusic lookup not enabled"];                                / return error if unenabled
   if[0=count msg;                                                                               / return help message if no input is provided
-    :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n* enter a username to attempt now playing lookup\n  users:",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]],"\n* enter 'user=<USERNAME>' to enter or update your own lastfm username\n* unset username by entering 'user='"
+    options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
+      "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)'";
+      "* Filters: tracks, artists\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
+      "  users:",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]]);
+    :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;
   ];
   if[msg like"user=*";                                                                          / update username for current user
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
@@ -17,7 +21,7 @@ mulo:{[x;y;z]
   `msg2 set msg;
   if[not(`$msg`name)in key .lfm.cache;:rc[;y;0]"\033[Guser not available"];                     / return error if requested user is unavailable
   rc[;y;0]"\033[GSending Request";
-  neg[wh](`.lfm.nowPlaying;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]);   / send request to worker process
+  neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
  };
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];

--- a/worker.q
+++ b/worker.q
@@ -18,39 +18,38 @@ dictlkup:{
 
 / last fm analysis
 .lfm.key:first@[read0;`:lfm_key;""];                                                            / api key
-.lfm.req:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
+.lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
 
-.lfm.filters:("tracks";"artists");
-.lfm.periods:("overall";"7day";"1month";"3month";"6month";"12month")!("";"7d ";"1m ";"3m ";"6m ";"12m ");
+.lfm.filters:("tracks";"artists");                                                              / allowed filters
+.lfm.periods:enlist["overall"]!enlist"";
+.lfm.periods:("7day";"1month";"3month";"6month";"12month")!"over last ",/:("7 days ";"1 month ";"3 months ";"6 months ";"12 months "); / allowed periods
 
-.lfm.parseMethod:{
-  if[not x[`filter]in .lfm.filters;:"user.getrecenttracks"];
+.lfm.parseMethod:{                                                                              / parse request methos
+  if[not x[`filter]in .lfm.filters;:"user.getrecenttracks"];                                    / default to recent tracks
   f:"user.gettop",x`filter;
-  if[x[`period]in key .lfm.periods;f,:"period=",x`period];
+  if[x[`period]in key .lfm.periods;f,:"&period=",x`period];                                     / add period if available
   :f;
  };
 
-.lfm.parse.recenttracks:{[x;y;z;m]
-  if[0=count m:m[`recenttracks]`track;:""];                                                     / no recent tracks for user
+.lfm.parse.recenttracks:{[x;y;z;m]                                                              / parser for recent tracks
+  if[0=count m:m[`recenttracks]`track;:""];                                                     / exit if no recent tracks for user
   r:$[(`$"@attr")in key a:first m;"is listening";"last listened"];                              / determine if song is currently playing
-  s:"'",a[`name],"' by ",a[`artist]`$"#text";                                                   / return track details
-  :" "sv(z`name;r;"to";s);
+  :" "sv(z`name;r;"to";"'",a[`name],"'";"by";a[`artist]`$"#text");                              / format message
  };
-.lfm.parse.toptracks:{[x;y;z;m]
-  if[0=count m:m[`toptracks]`track;:""];                                                        / no top tracks for user
+.lfm.parse.toptracks:{[x;y;z;m]                                                                 / parser for top tracks
+  if[0=count m:m[`toptracks]`track;:""];                                                        / exit if no top tracks for user
   s:" by "sv@[;0;{"'",x,"'"}]@[;1;first]first[m]`name`artist;
-  :z[`name],"'s top track ",.lfm.periods[z`period],"is ",s;
+  :z[`name],"'s top track ",.lfm.periods[z`period],"is ",s;                                     / format message
  };
-.lfm.parse.topartists:{[x;y;z;m]
-  if[0=count m:m[`topartists]`artist;:""];                                                      / no top tracks for user
-  s:first m`name;
-  :z[`name],"'s top artist ",.lfm.periods[z`period],"is ",s;
+.lfm.parse.topartists:{[x;y;z;m]                                                                / parser for top artists
+  if[0=count m:m[`topartists]`artist;:""];                                                      / exit if no top artists for user
+  :z[`name],"'s top artist ",.lfm.periods[z`period],"is ",first m`name;                         / format message
  };
 
-.lfm.nowPlaying:{[x;y;z]                                                                        / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
-  msg:.lfm.req[.lfm.parseMethod z]y;
-  if[not(k:first[key msg])in key .lfm.parse;:()];
-  res:.lfm.parse[k][x;y;z;msg];
+.lfm.request:{[x;y;z]                                                                           / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
+  msg:.lfm.httpGet[.lfm.parseMethod z]y;                                                        / make request to last fm
+  if[not(k:first[key msg])in key .lfm.parse;:()];                                               / exit if improper message returned
+  res:.lfm.parse[k][x;y;z;msg];                                                                 / parse returned message
   if[0=count res;:()];                                                                          / no return on bad request
   :neg[.z.w](`worker;`music;"Hey ",x,", ",res);                                                 / pass message back to server
  };

--- a/worker.q
+++ b/worker.q
@@ -11,8 +11,8 @@ src:(),hsym`$"http://newsapi.org/v1/articles?source=",/:@[read0;`:sources.txt;en
 getheadline:{news:.j.k .Q.hg first 1?src;
   neg[.z.w](`worker;`news;raze"(",x,") "," - "sv(),/:"c"$enlist[news`source],first each?[1;news`articles]`title`description`url)}
 
-dictlkup:{ 
-  dictf:{$[2>count t:raze raze .j.k[.Q.hg `$"http://api.pearson.com/v2/dictionaries/entries?headword=",x,"&limit=1"][`results][`senses][0][`definition];"No Results Found";t]};
+dictlkup:{
+  dictf:{$[2>count t:raze raze .j.k[.Q.hg`$"http://api.pearson.com/v2/dictionaries/entries?headword=",x,"&limit=1"][`results;`senses][0][`definition];"No Results Found";t]};
   :neg[.z.w](`worker;`defino;raze"The definition of ",x," is: ",@[dictf;x;"unable to be retrieved."])
  };
 
@@ -23,9 +23,9 @@ dictlkup:{
   msg:.lfm.req y;
   if[`error in key msg;:()];                                                                    / error returned from lfm
   if[0=count m:msg[`recenttracks]`track;:()];                                                   / no recent tracks for user
-  if[not(`$"@attr")in key a:first m;:()];                                                       / user is currently not listening
+  r:$[(`$"@attr")in key a:first m;"is listening";"last listened"];                              / determine if song is currently playing
   s:"'",a[`name],"' by ",a[`artist]`$"#text";                                                   / return track details
-  :neg[.z.w](`worker;`music;"Hey ",x,", ",z," is listening to ",s);                             / pass message back to server
+  :neg[.z.w](`worker;`music;"Hey ",x," "sv((),",";z;r;"to";s));                                 / pass message back to server
  };
 
 / bitcoin

--- a/worker.q
+++ b/worker.q
@@ -21,14 +21,12 @@ dictlkup:{
 .lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
 
 .lfm.filters:("tracks";"artists");                                                              / allowed filters
-.lfm.periods:enlist["overall"]!enlist"";
-.lfm.periods:("7day";"1month";"3month";"6month";"12month")!"over last ",/:("7 days ";"1 month ";"3 months ";"6 months ";"12 months "); / allowed periods
+.lfm.periods:enlist["overall"]!enlist"overall ";
+.lfm.periods,:("7day";"1month";"3month";"6month";"12month")!"over last ",/:("7 days ";"1 month ";"3 months ";"6 months ";"12 months "); / allowed periods
 
 .lfm.parseMethod:{                                                                              / parse request methos
   if[not x[`filter]in .lfm.filters;:"user.getrecenttracks"];                                    / default to recent tracks
-  f:"user.gettop",x`filter;
-  if[x[`period]in key .lfm.periods;f,:"&period=",x`period];                                     / add period if available
-  :f;
+  :"user.gettop",x[`filter],"&period=",x`period;
  };
 
 .lfm.parse.recenttracks:{[x;y;z;m]                                                              / parser for recent tracks
@@ -47,6 +45,7 @@ dictlkup:{
  };
 
 .lfm.request:{[x;y;z]                                                                           / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
+  if[not z[`period]in key .lfm.periods;z[`period]:"7day"];
   msg:.lfm.httpGet[.lfm.parseMethod z]y;                                                        / make request to last fm
   if[not(k:first[key msg])in key .lfm.parse;:()];                                               / exit if improper message returned
   res:.lfm.parse[k][x;y;z;msg];                                                                 / parse returned message


### PR DESCRIPTION
Update to expand on functionality.
* Users now get last played track if now playing is not available
* Can call to get users top tracks and artists over various periods. E.g:
```
\ml user1&artists
\ml user2&tracks&1month
```
* requests with optional parameters will default to 'now playing' if a user supplies incorrect filters.