### PR TITLE
Lfm chart

### DIFF
--- a/bots.q
+++ b/bots.q
@@ -14,7 +14,9 @@ mulo:{[x;y;z]
   ];
   if[msg like"chart*";
     rc[;y;0]"\033[GSending Chart Request";
-    :getchart .z.u;
+    msg:"&"vs msg;
+    if[not(u:`$trim msg 1)in key .lfm.cache;u:`];
+    :getchart[.z.u;u];
   ];
   if[msg like"user=*";                                                                          / update username for current user
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
@@ -26,14 +28,16 @@ mulo:{[x;y;z]
   neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
  };
 
-getchart:{[x]
+getchart:{[x;y]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
-  neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
-  if[not`getchart in cron`action;`cron insert(09:30+1+.z.D;`getchart;`update)];
+  d:`u`f`c!(trim ucn[x;string x];y;trim ucn[y;string y]);
+  neg[wh](`.lfm.getChart;d;{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
+  if[not`getchart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];
  };
-getchart`update;
+updatechart:getchart[`];
+updatechart`update;
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];
  if[not (c:`$upper trim"c"$3_x) in `USD`GBP`EUR`PLOT;:rc[;y;0]"\033[GUnsupported currency/option. Supported currencies: gbp,usd,eur. Options: plot"];

--- a/bots.q
+++ b/bots.q
@@ -7,7 +7,7 @@ mulo:{[x;y;z]
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_x;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
-      "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)'";
+      "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)' OR '\\ml chart'";
       "* Filters: tracks, artists\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users:",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]]);
     :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;
@@ -21,11 +21,11 @@ mulo:{[x;y;z]
     :rc[;y;0]"\033[GUpdated username";
   ];
   msg:@[;`filter`period;lower]{(count[x]#`name`filter`period)!x}"&"vs msg;                      / split message parameters
-  `msg2 set msg;
   if[not(`$msg`name)in key .lfm.cache;:rc[;y;0]"\033[Guser not available"];                     / return error if requested user is unavailable
   rc[;y;0]"\033[GSending Request";
   neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
  };
+
 getchart:{[x]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames

--- a/bots.q
+++ b/bots.q
@@ -31,9 +31,9 @@ getchart:{[x]
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
   neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
-  if[not`getchart in cron`action;`cron insert(.z.P+"v"$60*15;`getchart;`)];
+  if[not`getchart in cron`action;`cron insert(09:30+1+.z.D;`getchart;`update)];
  };
-getchart`;
+getchart`update;
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];
  if[not (c:`$upper trim"c"$3_x) in `USD`GBP`EUR`PLOT;:rc[;y;0]"\033[GUnsupported currency/option. Supported currencies: gbp,usd,eur. Options: plot"];

--- a/bots.q
+++ b/bots.q
@@ -30,14 +30,10 @@ getchart:{[x]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
-/  if[0=count .lfm.chart;
-   neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
-/  ];
-  if[not`getchart in cron`action;
-    `cron insert(.z.P+"v"$60*15;`getchart;`);
-  ];
+  neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
+  if[not`getchart in cron`action;`cron insert(.z.P+"v"$60*15;`getchart;`)];
  };
-/getchart`;
+getchart`;
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];
  if[not (c:`$upper trim"c"$3_x) in `USD`GBP`EUR`PLOT;:rc[;y;0]"\033[GUnsupported currency/option. Supported currencies: gbp,usd,eur. Options: plot"];

--- a/bots.q
+++ b/bots.q
@@ -14,7 +14,7 @@ mulo:{[x;y;z]
   ];
   if[msg like"chart*";
     rc[;y;0]"\033[GSending Chart Request";
-    :getchart`;
+    :getchart .z.u;
   ];
   if[msg like"user=*";                                                                          / update username for current user
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
@@ -26,12 +26,12 @@ mulo:{[x;y;z]
   rc[;y;0]"\033[GSending Request";
   neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
  };
-getchart:{
+getchart:{[x]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
 /  if[0=count .lfm.chart;
-   neg[wh](`.lfm.getChart;"";({trim ucn'[x;string x]}key .lfm.cache)!value .lfm.cache);
+   neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
 /  ];
   if[not`getchart in cron`action;
     `cron insert(.z.P+"v"$60*15;`getchart;`);

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -1,0 +1,66 @@
+/ Last FM bot code
+.lfm.key:first@[read0;`:lfm_key;""];                                                            / api key
+.lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
+
+.lfm.filters:("tracks";"artists");                                                              / allowed filters
+.lfm.periods:enlist["overall"]!enlist"overall ";
+.lfm.periods,:("7day";"1month";"3month";"6month";"12month")!"over the last ",/:("7 days ";"1 month ";"3 months ";"6 months ";"12 months "); / allowed periods
+
+.lfm.parseMethod:{                                                                              / parse request methos
+  if[not x[`filter]in .lfm.filters;:"user.getrecenttracks"];                                    / default to recent tracks
+  :"user.gettop",x[`filter],"&limit=1&period=",x`period;
+ };
+
+.lfm.parse.recenttracks:{[x;y;z;m]                                                              / parser for recent tracks
+  if[0=count m:m[`recenttracks]`track;:""];                                                     / exit if no recent tracks for user
+  r:$[(`$"@attr")in key a:first m;"is listening";"last listened"];                              / determine if song is currently playing
+  s:raze{"'",x[0],"' by ",x[1]," from ",x 2}@[;1 2;first]first[m]`name`artist`album;
+  :" "sv(z`name;r;"to";s);                                                                      / format message
+ };
+.lfm.parse.toptracks:{[x;y;z;m]                                                                 / parser for top tracks
+  if[0=count m:m[`toptracks]`track;:""];                                                        / exit if no top tracks for user
+  s:" by "sv@[;0;{"'",x,"'"}]@[;1;first]first[m]`name`artist;
+  :raze z[`name],"'s top track ",.lfm.periods[z`period],"is ",s," with ",m[`playcount]," scrobbles"; / format message
+ };
+.lfm.parse.topartists:{[x;y;z;m]                                                                / parser for top artists
+  if[0=count m:m[`topartists]`artist;:""];                                                      / exit if no top artists for user
+  :raze z[`name],"'s top artist ",.lfm.periods[z`period],"is ",first[m`name]," with ",m[`playcount]," scrobbles"; / format message
+ };
+
+.lfm.request:{[x;y;z]                                                                           / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
+  if[not z[`period]in key .lfm.periods;z[`period]:"7day"];                                      / set default period
+  msg:.lfm.httpGet[.lfm.parseMethod z]y;                                                        / make request to last fm
+  if[not(k:first key msg)in key .lfm.parse;:()];                                                / exit if improper message returned
+  res:.lfm.parse[k][x;y;z;msg];                                                                 / parse returned message
+  if[0=count res;:()];                                                                          / no return on bad request
+  :neg[.z.w](`worker;`music;"Hey ",x,", ",res);                                                 / pass message back to server
+ };
+
+.lfm.getChartUser:{[x;y]
+  res:first{
+    r:.lfm.httpGet["user.gettoptracks&period=7day&page=",string y 1;x];
+    if[0=count l:r[`toptracks]`track;:y];
+    y[0]:y[0],select name,{x`name}'[artist],"J"$playcount from l;
+    @[y;1;1+]
+  }[y]/[(();1)];
+  if[98=type res;:update users:x from res];
+  :res;
+ };
+
+.lfm.getChart:{[x;y;z]
+  res:@[get;`.lfm.chart;()];
+  if[(""~x`u)or 0=count res;                                                                    / if called from cron update results after 9.30am
+    res:raze .lfm.getChartUser'[key z;value z];
+    `.lfm.chart set res;
+  ];
+  e:"";
+  if[not any ``update=x`f;
+    res:select from res where users=x`f;
+    e:raze"for ",string[x`c]," ";
+  ];
+  if[0=count res;:()];                                                                          / no return for empty chart
+  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
+  res:select no:1+i,name,artist,scrobbles,users from res;
+  res:5#res;
+  :neg[.z.w](`worker;`music;$[""~x`u;"T";"Hey ",x[`u],", t"],"he current chart ",e,"is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]); / pass message back to server
+ };

--- a/worker.q
+++ b/worker.q
@@ -3,6 +3,9 @@
 / update default seed
 system"S ",string"j"$.z.T;
 
+/ load additional worker code
+\l lfm_worker.q
+
 /Powered by News API
 /default BBC
 news_key:first@[read0;`:news_key;""];
@@ -16,72 +19,6 @@ dictlkup:{
   :neg[.z.w](`worker;`defino;raze"The definition of ",x," is: ",@[dictf;x;"unable to be retrieved."])
  };
 
-/ last fm analysis
-.lfm.key:first@[read0;`:lfm_key;""];                                                            / api key
-.lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
-
-.lfm.filters:("tracks";"artists");                                                              / allowed filters
-.lfm.periods:enlist["overall"]!enlist"overall ";
-.lfm.periods,:("7day";"1month";"3month";"6month";"12month")!"over the last ",/:("7 days ";"1 month ";"3 months ";"6 months ";"12 months "); / allowed periods
-
-.lfm.parseMethod:{                                                                              / parse request methos
-  if[not x[`filter]in .lfm.filters;:"user.getrecenttracks"];                                    / default to recent tracks
-  :"user.gettop",x[`filter],"&limit=1&period=",x`period;
- };
-
-.lfm.parse.recenttracks:{[x;y;z;m]                                                              / parser for recent tracks
-  if[0=count m:m[`recenttracks]`track;:""];                                                     / exit if no recent tracks for user
-  r:$[(`$"@attr")in key a:first m;"is listening";"last listened"];                              / determine if song is currently playing
-  s:raze{"'",x[0],"' by ",x[1]," from ",x 2}@[;1 2;first]first[m]`name`artist`album;
-  :" "sv(z`name;r;"to";s);                                                                      / format message
- };
-.lfm.parse.toptracks:{[x;y;z;m]                                                                 / parser for top tracks
-  if[0=count m:m[`toptracks]`track;:""];                                                        / exit if no top tracks for user
-  s:" by "sv@[;0;{"'",x,"'"}]@[;1;first]first[m]`name`artist;
-  :raze z[`name],"'s top track ",.lfm.periods[z`period],"is ",s," with ",m[`playcount]," scrobbles"; / format message
- };
-.lfm.parse.topartists:{[x;y;z;m]                                                                / parser for top artists
-  if[0=count m:m[`topartists]`artist;:""];                                                      / exit if no top artists for user
-  :raze z[`name],"'s top artist ",.lfm.periods[z`period],"is ",first[m`name]," with ",m[`playcount]," scrobbles"; / format message
- };
-
-.lfm.request:{[x;y;z]                                                                           / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
-  if[not z[`period]in key .lfm.periods;z[`period]:"7day"];                                      / set default period
-  msg:.lfm.httpGet[.lfm.parseMethod z]y;                                                        / make request to last fm
-  if[not(k:first key msg)in key .lfm.parse;:()];                                                / exit if improper message returned
-  res:.lfm.parse[k][x;y;z;msg];                                                                 / parse returned message
-  if[0=count res;:()];                                                                          / no return on bad request
-  :neg[.z.w](`worker;`music;"Hey ",x,", ",res);                                                 / pass message back to server
- };
-
-.lfm.getChartUser:{[x;y]
-  res:first{
-    r:.lfm.httpGet["user.gettoptracks&period=7day&page=",string y 1;x];
-    if[0=count l:r[`toptracks]`track;:y];
-    y[0]:y[0],select name,{x`name}'[artist],"J"$playcount from l;
-    @[y;1;1+]
-  }[y]/[(();1)];
-  if[98=type res;:update users:x from res];
-  :res;
- };
-.lfm.getChart:{[x;y;z]
-  res:@[get;`.lfm.chart;()];
-  if[(""~x`u)or 0=count res;                                                                    / if called from cron update results after 9.30am
-    res:raze .lfm.getChartUser'[key z;value z];
-    `.lfm.chart set res;
-  ];
-  e:"";
-  if[not any ``update=x`f;
-    res:select from res where users=x`f;
-    e:raze"for ",string[x`c]," ";
-  ];
-  if[0=count res;:()];                                                                          / no return for empty chart
-  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
-  res:select no:1+i,name,artist,scrobbles,users from res;
-  res:5#res;
-  :neg[.z.w](`worker;`music;$[""~x`u;"T";"Hey ",x[`u],", t"],"he current chart ",e,"is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]); / pass message back to server
- };
-
 / bitcoin
 .btc.getprice:{
  if[y=`PLOT;:neg[.z.w](`worker;`bitcoin;"Hey ",x,", BTC price over last month:","\n" sv 1_read0`:/tmp/btc.txt)];
@@ -89,3 +26,4 @@ dictlkup:{
  d:`GBP`USD`EUR!("£";"$";"€");
  :neg[.z.w](`worker;`bitcoin;"Hey ",x,", bitcoin price is currently: ",d[y],j[`bpi][y][`rate]," (",string[y],")");
  }
+

--- a/worker.q
+++ b/worker.q
@@ -54,14 +54,18 @@ dictlkup:{
  };
 
 .lfm.getChart:{[x;y;z]
-  // logic to determine if request should be made or return cache
-  msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                  / make request to last fm
-  res:raze{[x;y]
-    :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from (5&count x)#x:x[`toptracks]`track;
-  }'[msg;key z];
-  res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
-  res:select no:1+i,name,artist,plays:playcount,users from res;
-  `:lfm_chart set res;
+  .lfm.chartDate:@[get;`.lfm.chartDate;09:30+.z.D];                                             / get timestamp of next update
+  res:@[get;`.lfm.chart;()];
+  if[(x~"")&(0=count res)or .z.P>.lfm.chartDate;                                                / if called from cron update results after 9.30am
+    msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                / make request to last fm
+    res:raze{[x;y]
+      :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from(5&count x)#x:x[`toptracks]`track;
+    }'[msg;key z];
+    res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
+    res:select no:1+i,name,artist,plays:playcount,users from res;
+    `.lfm.chart set res;
+    `.lfm.chartDate set 09:30+1+.z.D;
+  ];
   :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;string key z;y]);          / pass message back to server
  };
 

--- a/worker.q
+++ b/worker.q
@@ -54,19 +54,19 @@ dictlkup:{
  };
 
 .lfm.getChart:{[x;y;z]
-  .lfm.chartDate:@[get;`.lfm.chartDate;09:30+.z.D];                                             / get timestamp of next update
   res:@[get;`.lfm.chart;()];
-  if[(x~"")&(0=count res)or .z.P>.lfm.chartDate;                                                / if called from cron update results after 9.30am
-    msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                / make request to last fm
+  if[(x~"update")or 0=count res;                                                                / if called from cron update results after 9.30am
+    msg:.lfm.httpGet["user.gettoptracks&period=7day&limit=5"]'[value z];                         / make request to last fm
     res:raze{[x;y]
-      :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from(5&count x)#x:x[`toptracks]`track;
+      :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from x[`toptracks]`track;
     }'[msg;key z];
-    res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
-    res:select no:1+i,name,artist,plays:playcount,users from res;
+    res:0!5#`playcount xdesc select plays:sum playcount,users by name,artist from res;
+    res:select no:1+i,name,artist,play,users from res;
     `.lfm.chart set res;
-    `.lfm.chartDate set 09:30+1+.z.D;
+    x:"";
   ];
-  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;string key z;y]);          / pass message back to server
+  if[0=count res;:()];                                                                          / no return for empty chart
+  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]);          / pass message back to server
  };
 
 / bitcoin

--- a/worker.q
+++ b/worker.q
@@ -53,16 +53,16 @@ dictlkup:{
   :neg[.z.w](`worker;`music;"Hey ",x,", ",res);                                                 / pass message back to server
  };
 
-.lfm.getChart:{[x;y]
+.lfm.getChart:{[x;y;z]
   // logic to determine if request should be made or return cache
-  msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value y];                                  / make request to last fm
+  msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                  / make request to last fm
   res:raze{[x;y]
     :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from (5&count x)#x:x[`toptracks]`track;
-  }'[msg;key y];
+  }'[msg;key z];
   res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
   res:select no:1+i,name,artist,plays:playcount,users from res;
   `:lfm_chart set res;
-  :neg[.z.w](`worker;`music;"The current chart is:\n","\n"sv"  ",/:"\n"vs .Q.s res);            / pass message back to server
+  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;string key z;y]);          / pass message back to server
  };
 
 / bitcoin

--- a/worker.q
+++ b/worker.q
@@ -55,18 +55,23 @@ dictlkup:{
 
 .lfm.getChart:{[x;y;z]
   res:@[get;`.lfm.chart;()];
-  if[(x~"update")or 0=count res;                                                                / if called from cron update results after 9.30am
-    msg:.lfm.httpGet["user.gettoptracks&period=7day&limit=5"]'[value z];                         / make request to last fm
+  if[(""~x`u)or 0=count res;                                                                    / if called from cron update results after 9.30am
+    msg:.lfm.httpGet["user.gettoptracks&period=7day&limit=5"]'[value z];                        / make request to last fm
     res:raze{[x;y]
       :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from x[`toptracks]`track;
     }'[msg;key z];
-    res:0!5#`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
-    res:select no:1+i,name,artist,scrobbles,users from res;
     `.lfm.chart set res;
-    if[x~"update";x:""];
   ];
   if[0=count res;:()];                                                                          / no return for empty chart
-  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]);          / pass message back to server
+  e:"";
+  if[not any ``update=x`f;
+    res:select from res where users=x`f;
+    e:raze"for ",string[x`c]," ";
+  ];
+  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
+  res:select no:1+i,name,artist,scrobbles,users from res;
+  res:5#res;
+  :neg[.z.w](`worker;`music;$[""~x`u;"T";"Hey ",x[`u],", t"],"he current chart ",e,"is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]); / pass message back to server
  };
 
 / bitcoin


### PR DESCRIPTION
Creates a chart of last 7 days, results updated at 9.30am, can be filtered by user.
```
\ml chart
\ml chart&user
```

Additionally:
* worker code has been moved to a seperate file (its becoming a bit large)
* now playing requests contain album
* 'top' requests contain playcount

If this gets merge then just squash the commits for simplicity.