### PR TITLE
Last FM Daily Charts

### DIFF
--- a/bots.q
+++ b/bots.q
@@ -14,7 +14,9 @@ mulo:{[x;y;z]
   ];
   if[msg like"chart*";
     rc[;y;0]"\033[GSending Chart Request";
-    :getchart .z.u;
+    msg:"&"vs msg;
+    if[not(u:`$trim msg 1)in key .lfm.cache;u:`];
+    :getchart[.z.u;u];
   ];
   if[msg like"user=*";                                                                          / update username for current user
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
@@ -26,14 +28,16 @@ mulo:{[x;y;z]
   neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
  };
 
-getchart:{[x]
+getchart:{[x;y]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
-  neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
-  if[not`getchart in cron`action;`cron insert(09:30+1+.z.D;`getchart;`update)];
+  d:`u`f`c!(trim ucn[x;string x];y;trim ucn[y;string y]);
+  neg[wh](`.lfm.getChart;d;{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
+  if[not`getchart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];
  };
-getchart`update;
+updatechart:getchart[`];
+updatechart`update;
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];
  if[not (c:`$upper trim"c"$3_x) in `USD`GBP`EUR`PLOT;:rc[;y;0]"\033[GUnsupported currency/option. Supported currencies: gbp,usd,eur. Options: plot"];

--- a/bots.q
+++ b/bots.q
@@ -8,7 +8,7 @@ mulo:{[x;y;z]
   if[0=count msg:trim"c"$3_x;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
       "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)' OR '\\ml chart'";
-      "* Filters: tracks, artists\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
+      "* Filters: tracks, artists, chart\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users: ",$[0=count k:key .lfm.cache;"()";atproc", "sv "@",'string k]);
     :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;
   ];

--- a/bots.q
+++ b/bots.q
@@ -9,7 +9,7 @@ mulo:{[x;y;z]
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
       "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)' OR '\\ml chart'";
       "* Filters: tracks, artists\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
-      "  users:",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]]);
+      "  users: ",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]]);
     :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;
   ];
   if[msg like"chart*";

--- a/bots.q
+++ b/bots.q
@@ -28,11 +28,11 @@ mulo:{[x;y;z]
   neg[wh](`.lfm.request;z;((),`$msg`name)#.lfm.cache;msg);                                      / send request to worker process
  };
 getchart:{[x;y;z]
+  if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];           / update cron
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];                                                                   / exit if no users are cached
   neg[wh](`.lfm.request;x;$[y=`;(::);((),y)#].lfm.cache;`filter`c!("chart";z));                 / send request
-  if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];           / update cron
  };
 updatechart:getchart[`;`];
 updatechart`update;                                                                             / initialise cron job

--- a/bots.q
+++ b/bots.q
@@ -3,6 +3,7 @@ labels,:("\\ne";"\\ml";"\\bc";"\\df")!("news";"music";"bitcoin";"define");
 news:{[x;y;z]rc[;y;0]"\033[GGetting news";neg[wh](`getheadline;uct string z);}
 defn:{[x;y;z] neg[wh](`dictlkup;trim "c"$3_x);}
 mulo:{[x;y;z]
+  `aa set(x;y;z);
   if[()~key`:lfm_key;:rc[;y;0]"\033[Gmusic lookup not enabled"];                                / return error if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_x;                                                                   / return help message if no input is provided
@@ -22,10 +23,10 @@ mulo:{[x;y;z]
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
     :rc[;y;0]"\033[GUpdated username";
   ];
-  msg:@[;`filter`period;lower]{(count[x]#`name`filter`period)!x}"&"vs msg;                      / split message parameters
+  msg:@[;`filter`period;lower]{(!).(3&count x)#/:(`name`filter`period;x)}"&"vs msg;             / split message parameters
   if[not(`$msg`name)in key .lfm.cache;:rc[;y;0]"\033[Guser not available"];                     / return error if requested user is unavailable
   rc[;y;0]"\033[GSending Request";
-  neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
+  neg[wh](`.lfm.request;z;((),`$msg`name)#.lfm.cache;msg);                                      / send request to worker process
  };
 
 getchart:{[x;y]

--- a/bots.q
+++ b/bots.q
@@ -7,7 +7,7 @@ mulo:{[x;y;z]
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_x;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
-      "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)'";
+      "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)' OR '\\ml chart'";
       "* Filters: tracks, artists\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users:",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]]);
     :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;
@@ -21,11 +21,11 @@ mulo:{[x;y;z]
     :rc[;y;0]"\033[GUpdated username";
   ];
   msg:@[;`filter`period;lower]{(count[x]#`name`filter`period)!x}"&"vs msg;                      / split message parameters
-  `msg2 set msg;
   if[not(`$msg`name)in key .lfm.cache;:rc[;y;0]"\033[Guser not available"];                     / return error if requested user is unavailable
   rc[;y;0]"\033[GSending Request";
   neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
  };
+
 getchart:{[x]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames

--- a/bots.q
+++ b/bots.q
@@ -10,14 +10,14 @@ mulo:{[x;y;z]
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
       "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)' OR '\\ml chart'";
       "* Filters: tracks, artists\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
-      "  users: ",$[0=count k:key .lfm.cache;"()";", "sv trim'[ucn'[k;string k]]]);
+      "  users: ",$[0=count k:key .lfm.cache;"()";atproc", "sv "@",'string k]);
     :rc[;y;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;
   ];
   if[msg like"chart*";
     rc[;y;0]"\033[GSending Chart Request";
     msg:"&"vs msg;
     if[not(u:`$trim msg 1)in key .lfm.cache;u:`];
-    :getchart[.z.u;u];
+    :getchart[.z.u;u;`];
   ];
   if[msg like"user=*";                                                                          / update username for current user
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
@@ -29,15 +29,14 @@ mulo:{[x;y;z]
   neg[wh](`.lfm.request;z;((),`$msg`name)#.lfm.cache;msg);                                      / send request to worker process
  };
 
-getchart:{[x;y]
+getchart:{[x;y;z]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
-  d:`u`f`c!(trim ucn[x;string x];y;trim ucn[y;string y]);
-  neg[wh](`.lfm.getChart;d;{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
-  if[not`getchart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];
+  neg[wh](`.lfm.getChart;x;$[y=`;(::);((),y)#].lfm.cache;enlist[`c]!enlist z);
+  if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];
  };
-updatechart:getchart[`];
+updatechart:getchart[`;`];
 updatechart`update;
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];

--- a/bots.q
+++ b/bots.q
@@ -31,9 +31,9 @@ getchart:{[x]
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
   neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
-  if[not`getchart in cron`action;`cron insert(.z.P+"v"$60*15;`getchart;`)];
+  if[not`getchart in cron`action;`cron insert(09:30+1+.z.D;`getchart;`update)];
  };
-getchart`;
+getchart`update;
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];
  if[not (c:`$upper trim"c"$3_x) in `USD`GBP`EUR`PLOT;:rc[;y;0]"\033[GUnsupported currency/option. Supported currencies: gbp,usd,eur. Options: plot"];

--- a/bots.q
+++ b/bots.q
@@ -30,14 +30,10 @@ getchart:{[x]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
-/  if[0=count .lfm.chart;
-   neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
-/  ];
-  if[not`getchart in cron`action;
-    `cron insert(.z.P+"v"$60*15;`getchart;`);
-  ];
+  neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
+  if[not`getchart in cron`action;`cron insert(.z.P+"v"$60*15;`getchart;`)];
  };
-/getchart`;
+getchart`;
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];
  if[not (c:`$upper trim"c"$3_x) in `USD`GBP`EUR`PLOT;:rc[;y;0]"\033[GUnsupported currency/option. Supported currencies: gbp,usd,eur. Options: plot"];

--- a/bots.q
+++ b/bots.q
@@ -3,7 +3,6 @@ labels,:("\\ne";"\\ml";"\\bc";"\\df")!("news";"music";"bitcoin";"define");
 news:{[x;y;z]rc[;y;0]"\033[GGetting news";neg[wh](`getheadline;uct string z);}
 defn:{[x;y;z] neg[wh](`dictlkup;trim "c"$3_x);}
 mulo:{[x;y;z]
-  `aa set(x;y;z);
   if[()~key`:lfm_key;:rc[;y;0]"\033[Gmusic lookup not enabled"];                                / return error if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_x;                                                                   / return help message if no input is provided
@@ -17,10 +16,10 @@ mulo:{[x;y;z]
     rc[;y;0]"\033[GSending Chart Request";
     msg:"&"vs msg;
     if[not(u:`$trim msg 1)in key .lfm.cache;u:`];
-    :getchart[.z.u;u;`];
+    :getchart[z;u;`];
   ];
   if[msg like"user=*";                                                                          / update username for current user
-    `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
+    `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;z _.lfm.cache;.lfm.cache,enlist[z]!enlist uname]; / update cache
     :rc[;y;0]"\033[GUpdated username";
   ];
   msg:@[;`filter`period;lower]{(!).(3&count x)#/:(`name`filter`period;x)}"&"vs msg;             / split message parameters
@@ -28,16 +27,16 @@ mulo:{[x;y;z]
   rc[;y;0]"\033[GSending Request";
   neg[wh](`.lfm.request;z;((),`$msg`name)#.lfm.cache;msg);                                      / send request to worker process
  };
-
 getchart:{[x;y;z]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
-  if[0=count .lfm.cache;:()];
-  neg[wh](`.lfm.getChart;x;$[y=`;(::);((),y)#].lfm.cache;enlist[`c]!enlist z);
-  if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];
+  if[0=count .lfm.cache;:()];                                                                   / exit if no users are cached
+  neg[wh](`.lfm.request;x;$[y=`;(::);((),y)#].lfm.cache;`filter`c!("chart";z));                 / send request
+  if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];           / update cron
  };
 updatechart:getchart[`;`];
-updatechart`update;
+updatechart`update;                                                                             / initialise cron job
+
 btcp:{[x;y;z]
  if[`~`$upper trim"c"$3_x;x:"xxxUSD"];
  if[not (c:`$upper trim"c"$3_x) in `USD`GBP`EUR`PLOT;:rc[;y;0]"\033[GUnsupported currency/option. Supported currencies: gbp,usd,eur. Options: plot"];

--- a/bots.q
+++ b/bots.q
@@ -14,7 +14,7 @@ mulo:{[x;y;z]
   ];
   if[msg like"chart*";
     rc[;y;0]"\033[GSending Chart Request";
-    :getchart`;
+    :getchart .z.u;
   ];
   if[msg like"user=*";                                                                          / update username for current user
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;.z.u _.lfm.cache;.lfm.cache,enlist[.z.u]!enlist uname]; / update cache
@@ -26,12 +26,12 @@ mulo:{[x;y;z]
   rc[;y;0]"\033[GSending Request";
   neg[wh](`.lfm.request;trim uct string z;.lfm.cache`$msg`name;@[msg;`name;{trim ucn[`$x;x]}]); / send request to worker process
  };
-getchart:{
+getchart:{[x]
   if[()~key`:lfm_key;:()];                                                                      / exit if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count .lfm.cache;:()];
 /  if[0=count .lfm.chart;
-   neg[wh](`.lfm.getChart;"";({trim ucn'[x;string x]}key .lfm.cache)!value .lfm.cache);
+   neg[wh](`.lfm.getChart;trim ucn[x;string x];{trim ucn'[x;string x]}key .lfm.cache;.lfm.cache);
 /  ];
   if[not`getchart in cron`action;
     `cron insert(.z.P+"v"$60*15;`getchart;`);

--- a/func.q
+++ b/func.q
@@ -32,7 +32,7 @@ votr:{[x;y;z;f]if[gameon`vote;:rc[;y;0]"\033[GVoting is in progress";];
     `popt set {(1+til count x)!x}1_{#[5&count[x];x]}o:";"vs"c"$3_x;
     h::value[`atproc]"\n"sv enlist["Poll initialised. you have 10 seconds to enter a choice number:"],{@[string[til count x],\:"]. ";0;:;""],'x}o;];
   bc uvol[key aw],\:h;
-  @[`gameon;`vote;:;1b]; 
+  @[`gameon;`vote;:;1b];
   `cron insert (.z.P+"v"$10;endfuncs f;`);
   @[`tf;"";:;value f];};
 
@@ -183,7 +183,7 @@ bbks:{[x;y;z]chat[;y;z]'["j"$biggerbox . {(5&1^"J"$x[1];" " sv 2_x)} " " vs "c"$
 
 workernames:enlist[`]!enlist"[",$[10;"BLANK"],"]";
 
-worker:{publ[y;0;n:workernames x]}
+worker:{publ[atproc y;0;n:workernames x]}
 
 tf[""]:chat
 

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -49,18 +49,15 @@
 
 .lfm.getChart:{[x;y;z]
   res:@[get;`.lfm.chart;()];
-  if[(""~x`u)or 0=count res;                                                                    / if called from cron update results
-    res:raze{r:.lfm.ch y;if[98=type r;r:update users:x from r];r}'[key z;value z];
+  if[(`update~z`c)or 0=count res;                                                               / if called from cron update results
+    res:raze{r:.lfm.ch y;if[98=type r;r:update users:x from r];r}'[key y;value y];
     `.lfm.chart set res;
   ];
-  e:"";
-  if[not any ``update=x`f;
-    res:select from res where users=x`f;
-    e:raze"for ",string[x`c]," ";
-  ];
+  res:select from res where users in key y;
   if[0=count res;:()];                                                                          / no return for empty chart
+  e:$[1=count key y;"for @",string[first key y]," ";""];
   res:update("@",'string users)from res;                                                        / allow colours
   res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
   res:5#select no:1+i,name,artist,scrobbles,users from res;
-  :neg[.z.w](`worker;`music;ssr[;"\n";"\n  "]$[""~x`u;"T";"Hey ",x[`u],", t"],"he current chart ",e,"is:\n",.Q.s@[res;cols[res]where"C"=exec t from meta res;`$]); / pass message back to server
+  :neg[.z.w](`worker;`music;ssr[;"\n";"\n  "]$[`~x;"T";"Hey @",string[x],", t"],"he current chart ",e,"is:\n",.Q.s@[res;cols[res]where any"C "=\:exec t from meta res;`$]); / pass message back to server
  };

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -6,21 +6,22 @@
 .lfm.filters:("tracks";"artists")!`toptracks`topartists;                                        / allowed filters
 .lfm.periods:("overall";"7day";"1month";"3month";"6month";"12month")!("overall";"7 day";"1 month";"3 month";"6 month";"12 month"); / allowed periods
 .lfm.funcs:(`artist`playcount`album,`$"@attr")!(first;"J"$;first;{"true"~last x});              / column functions
-.lfm.cols:(`topartists;`toptracks;`recenttracks)!(`name`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr")); / columns for parsing requests
+.lfm.cols:`topartists`toptracks`recenttracks`chart!(`name`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr");`name`artist`playcount); / columns for parsing requests
 
 .lfm.request:{[x;y;z]                                                                           / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
+  if["chart"~z`filter;:.lfm.getChart[x;y;z]];
   res:.lfm.parseMethod[x;y;z];
   :neg[.z.w](`worker;`music;raze"Hey @",string[x],", @",string[first key y],res);               / pass message back to server
  };
 
 .lfm.parseMethod:{[x;y;z]                                                                       / parse request methos
   if[not z[`period]in key .lfm.periods;z[`period]:"7day"];                                      / set default period
-  a:$[z[`filter]in key .lfm.filters;
-    ("user.gettop",z[`filter],"&limit=1&period=",z`period;.lfm.filters z`filter);
-    ("user.getrecenttracks";`recenttracks)
+  a:$[z[`filter]in key .lfm.filters;                                                            / determine request params
+    (1;"user.gettop",z[`filter],"&period=",z`period;.lfm.filters z`filter);
+    (1;"user.getrecenttracks";`recenttracks)
   ];
-  res:.lfm.httpWrap[1;a 0;first value y;(.lfm.cols a 1)#.lfm.funcs];
-  :.lfm.parse[a 1][.lfm.periods z`period;first res];
+  res:first raze .lfm.httpWrap[a 0;a 1;;;.lfm.cols[a 2]#.lfm.funcs]'[key y;value y];            / http request
+  :.lfm.parse[a 2][.lfm.periods z`period;res];                                                  / parse results
  };
 
 .lfm.parse.recenttracks:{[z;m]                                                                  / parser for recent tracks
@@ -34,30 +35,29 @@
   :"'s ",z," top artist is ",m[`name]," with ",string[m`playcount]," scrobbles";                / format message
  };
 
-.lfm.httpWrap:{[p;x;y;z]
+.lfm.httpWrap:{[p;x;u;y;z]                                                                      / [limit;request;user;lfm name;cols+funcs]
   q:$[p=0W;("";1b);("&limit=",string p;0b)];                                                    / limit results if necessary
   res:first{[q;x;y;z]                                                                           / loop over pages to get all tracks
-    r:.lfm.httpGet[x,q[0],"&page=",string z 1;y];
-    if[0=count l:first raze r;:z];
-    z[0]:distinct z[0],{@/[;x;y]x#z}[z 2;z 3]'[l];
-    :@[z;1;+;q 1];
+    r:.lfm.httpGet[x,q[0],"&page=",string z 1;y];                                               / api request
+    if[0=count l:first raze r;:z];                                                              / exit early if no results
+    z[0]:distinct z[0],{@/[;x;y]x#z}[z 2;z 3]'[l];                                              / update results
+    :@[z;1;+;q 1];                                                                              / increment page number
   }[q;x;y]/[(();1;key z;value z)];
+  if[98=type res;:update users:u from res];                                                     / add username
   :res;
  };
 
-.lfm.ch:.lfm.httpWrap[0W;"user.gettoptracks&period=7day";;`name`artist`playcount!(::;first;"J"$)];
-
 .lfm.getChart:{[x;y;z]
-  res:@[get;`.lfm.chart;()];
+  res:@[get;`.lfm.chart;()];                                                                    / get cache chart
   if[(`update~z`c)or 0=count res;                                                               / if called from cron update results
-    res:raze{r:.lfm.ch y;if[98=type r;r:update users:x from r];r}'[key y;value y];
-    `.lfm.chart set res;
+    res:raze .lfm.httpWrap[0W;"user.gettoptracks&period=7day";;;.lfm.cols[`chart]#.lfm.funcs]'[key y;value y]; / http request
+    `.lfm.chart set res;                                                                        / cache results
   ];
-  res:select from res where users in key y;
+  res:select from res where users in key y;                                                     / filter by user
   if[0=count res;:()];                                                                          / no return for empty chart
-  e:$[1=count key y;"for @",string[first key y]," ";""];
+  e:$[1=count key y;"for @",string[first key y]," ";""];                                        / name of requested user
   res:update("@",'string users)from res;                                                        / allow colours
-  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
-  res:5#select no:1+i,name,artist,scrobbles,users from res;
+  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;          / amalgamate results
+  res:5#select no:1+i,name,artist,scrobbles,users from res;                                     / return 5
   :neg[.z.w](`worker;`music;ssr[;"\n";"\n  "]$[`~x;"T";"Hey @",string[x],", t"],"he current chart ",e,"is:\n",.Q.s@[res;cols[res]where any"C "=\:exec t from meta res;`$]); / pass message back to server
  };

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -1,0 +1,66 @@
+/ Last FM bot code
+.lfm.key:first@[read0;`:lfm_key;""];                                                            / api key
+.lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
+
+.lfm.filters:("tracks";"artists");                                                              / allowed filters
+.lfm.periods:enlist["overall"]!enlist"overall ";
+.lfm.periods,:("7day";"1month";"3month";"6month";"12month")!"over the last ",/:("7 days ";"1 month ";"3 months ";"6 months ";"12 months "); / allowed periods
+
+.lfm.parseMethod:{                                                                              / parse request methos
+  if[not x[`filter]in .lfm.filters;:"user.getrecenttracks"];                                    / default to recent tracks
+  :"user.gettop",x[`filter],"&limit=1&period=",x`period;
+ };
+
+.lfm.parse.recenttracks:{[x;y;z;m]                                                              / parser for recent tracks
+  if[0=count m:m[`recenttracks]`track;:""];                                                     / exit if no recent tracks for user
+  r:$[(`$"@attr")in key a:first m;"is listening";"last listened"];                              / determine if song is currently playing
+  s:raze{"'",x[0],"' by ",x[1]," from ",x 2}@[;1 2;first]first[m]`name`artist`album;
+  :" "sv(z`name;r;"to";s);                                                                      / format message
+ };
+.lfm.parse.toptracks:{[x;y;z;m]                                                                 / parser for top tracks
+  if[0=count m:m[`toptracks]`track;:""];                                                        / exit if no top tracks for user
+  s:" by "sv@[;0;{"'",x,"'"}]@[;1;first]first[m]`name`artist;
+  :raze z[`name],"'s top track ",.lfm.periods[z`period],"is ",s," with ",m[`playcount]," scrobbles"; / format message
+ };
+.lfm.parse.topartists:{[x;y;z;m]                                                                / parser for top artists
+  if[0=count m:m[`topartists]`artist;:""];                                                      / exit if no top artists for user
+  :raze z[`name],"'s top artist ",.lfm.periods[z`period],"is ",first[m`name]," with ",m[`playcount]," scrobbles"; / format message
+ };
+
+.lfm.request:{[x;y;z]                                                                           / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
+  if[not z[`period]in key .lfm.periods;z[`period]:"7day"];                                      / set default period
+  msg:.lfm.httpGet[.lfm.parseMethod z]y;                                                        / make request to last fm
+  if[not(k:first key msg)in key .lfm.parse;:()];                                                / exit if improper message returned
+  res:.lfm.parse[k][x;y;z;msg];                                                                 / parse returned message
+  if[0=count res;:()];                                                                          / no return on bad request
+  :neg[.z.w](`worker;`music;"Hey ",x,", ",res);                                                 / pass message back to server
+ };
+
+.lfm.getChartUser:{[x;y]
+  res:first{
+    r:.lfm.httpGet["user.gettoptracks&period=7day&page=",string y 1;x];
+    if[0=count l:r[`toptracks]`track;:y];
+    y[0]:y[0],select name,{x`name}'[artist],"J"$playcount from l;
+    @[y;1;1+]
+  }[y]/[(();1)];
+  if[98=type res;:update users:x from res];
+  :res;
+ };
+
+.lfm.getChart:{[x;y;z]
+  res:@[get;`.lfm.chart;()];
+  if[(""~x`u)or 0=count res;                                                                    / if called from cron update results after 9.30am
+    res:raze .lfm.getChartUser'[key z;value z];
+    `.lfm.chart set res;
+  ];
+  e:"";
+  if[not any ``update=x`f;
+    res:select from res where users=x`f;
+    e:raze"for ",string[x`c]," ";
+  ];
+  if[0=count res;:()];                                                                          / no return for empty chart
+  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
+  res:select no:1+i,name,artist,scrobbles,users from res;
+  res:5#res;
+  :neg[.z.w](`worker;`music;$[""~x`u;"T";"Hey ",x[`u],", t"],"he current chart ",e,"is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]); / pass message back to server
+ };

--- a/worker.q
+++ b/worker.q
@@ -3,6 +3,9 @@
 / update default seed
 system"S ",string"j"$.z.T;
 
+/ load additional worker code
+\l lfm_worker.q
+
 /Powered by News API
 /default BBC
 news_key:first@[read0;`:news_key;""];
@@ -16,72 +19,6 @@ dictlkup:{
   :neg[.z.w](`worker;`defino;raze"The definition of ",x," is: ",@[dictf;x;"unable to be retrieved."])
  };
 
-/ last fm analysis
-.lfm.key:first@[read0;`:lfm_key;""];                                                            / api key
-.lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
-
-.lfm.filters:("tracks";"artists");                                                              / allowed filters
-.lfm.periods:enlist["overall"]!enlist"overall ";
-.lfm.periods,:("7day";"1month";"3month";"6month";"12month")!"over the last ",/:("7 days ";"1 month ";"3 months ";"6 months ";"12 months "); / allowed periods
-
-.lfm.parseMethod:{                                                                              / parse request methos
-  if[not x[`filter]in .lfm.filters;:"user.getrecenttracks"];                                    / default to recent tracks
-  :"user.gettop",x[`filter],"&limit=1&period=",x`period;
- };
-
-.lfm.parse.recenttracks:{[x;y;z;m]                                                              / parser for recent tracks
-  if[0=count m:m[`recenttracks]`track;:""];                                                     / exit if no recent tracks for user
-  r:$[(`$"@attr")in key a:first m;"is listening";"last listened"];                              / determine if song is currently playing
-  s:raze{"'",x[0],"' by ",x[1]," from ",x 2}@[;1 2;first]first[m]`name`artist`album;
-  :" "sv(z`name;r;"to";s);                                                                      / format message
- };
-.lfm.parse.toptracks:{[x;y;z;m]                                                                 / parser for top tracks
-  if[0=count m:m[`toptracks]`track;:""];                                                        / exit if no top tracks for user
-  s:" by "sv@[;0;{"'",x,"'"}]@[;1;first]first[m]`name`artist;
-  :raze z[`name],"'s top track ",.lfm.periods[z`period],"is ",s," with ",m[`playcount]," scrobbles"; / format message
- };
-.lfm.parse.topartists:{[x;y;z;m]                                                                / parser for top artists
-  if[0=count m:m[`topartists]`artist;:""];                                                      / exit if no top artists for user
-  :raze z[`name],"'s top artist ",.lfm.periods[z`period],"is ",first[m`name]," with ",m[`playcount]," scrobbles"; / format message
- };
-
-.lfm.request:{[x;y;z]                                                                           / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
-  if[not z[`period]in key .lfm.periods;z[`period]:"7day"];                                      / set default period
-  msg:.lfm.httpGet[.lfm.parseMethod z]y;                                                        / make request to last fm
-  if[not(k:first key msg)in key .lfm.parse;:()];                                                / exit if improper message returned
-  res:.lfm.parse[k][x;y;z;msg];                                                                 / parse returned message
-  if[0=count res;:()];                                                                          / no return on bad request
-  :neg[.z.w](`worker;`music;"Hey ",x,", ",res);                                                 / pass message back to server
- };
-
-.lfm.getChartUser:{[x;y]
-  res:first{
-    r:.lfm.httpGet["user.gettoptracks&period=7day&page=",string y 1;x];
-    if[0=count l:r[`toptracks]`track;:y];
-    y[0]:y[0],select name,{x`name}'[artist],"J"$playcount from l;
-    @[y;1;1+]
-  }[y]/[(();1)];
-  if[98=type res;:update users:x from res];
-  :res;
- };
-.lfm.getChart:{[x;y;z]
-  res:@[get;`.lfm.chart;()];
-  if[(""~x`u)or 0=count res;                                                                    / if called from cron update results after 9.30am
-    res:raze .lfm.getChartUser'[key z;value z];
-    `.lfm.chart set res;
-  ];
-  e:"";
-  if[not any ``update=x`f;
-    res:select from res where users=x`f;
-    e:raze"for ",string[x`c]," ";
-  ];
-  if[0=count res;:()];                                                                          / no return for empty chart
-  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
-  res:select no:1+i,name,artist,scrobbles,users from res;
-  res:5#res;
-  :neg[.z.w](`worker;`music;$[""~x`u;"T";"Hey ",x[`u],", t"],"he current chart ",e,"is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]); / pass message back to server
- };
-
 / bitcoin
 .btc.getprice:{
  if[y=`PLOT;:neg[.z.w](`worker;`bitcoin;"Hey ",x,", BTC price over last month:","\n" sv 1_read0`:/tmp/btc.txt)];
@@ -89,3 +26,4 @@ dictlkup:{
  d:`GBP`USD`EUR!("£";"$";"€");
  :neg[.z.w](`worker;`bitcoin;"Hey ",x,", bitcoin price is currently: ",d[y],j[`bpi][y][`rate]," (",string[y],")");
  }
+

--- a/worker.q
+++ b/worker.q
@@ -54,14 +54,18 @@ dictlkup:{
  };
 
 .lfm.getChart:{[x;y;z]
-  // logic to determine if request should be made or return cache
-  msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                  / make request to last fm
-  res:raze{[x;y]
-    :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from (5&count x)#x:x[`toptracks]`track;
-  }'[msg;key z];
-  res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
-  res:select no:1+i,name,artist,plays:playcount,users from res;
-  `:lfm_chart set res;
+  .lfm.chartDate:@[get;`.lfm.chartDate;09:30+.z.D];                                             / get timestamp of next update
+  res:@[get;`.lfm.chart;()];
+  if[(x~"")&(0=count res)or .z.P>.lfm.chartDate;                                                / if called from cron update results after 9.30am
+    msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                / make request to last fm
+    res:raze{[x;y]
+      :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from(5&count x)#x:x[`toptracks]`track;
+    }'[msg;key z];
+    res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
+    res:select no:1+i,name,artist,plays:playcount,users from res;
+    `.lfm.chart set res;
+    `.lfm.chartDate set 09:30+1+.z.D;
+  ];
   :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;string key z;y]);          / pass message back to server
  };
 

--- a/worker.q
+++ b/worker.q
@@ -54,19 +54,19 @@ dictlkup:{
  };
 
 .lfm.getChart:{[x;y;z]
-  .lfm.chartDate:@[get;`.lfm.chartDate;09:30+.z.D];                                             / get timestamp of next update
   res:@[get;`.lfm.chart;()];
-  if[(x~"")&(0=count res)or .z.P>.lfm.chartDate;                                                / if called from cron update results after 9.30am
-    msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                / make request to last fm
+  if[(x~"update")or 0=count res;                                                                / if called from cron update results after 9.30am
+    msg:.lfm.httpGet["user.gettoptracks&period=7day&limit=5"]'[value z];                         / make request to last fm
     res:raze{[x;y]
-      :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from(5&count x)#x:x[`toptracks]`track;
+      :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from x[`toptracks]`track;
     }'[msg;key z];
-    res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
-    res:select no:1+i,name,artist,plays:playcount,users from res;
+    res:0!5#`playcount xdesc select plays:sum playcount,users by name,artist from res;
+    res:select no:1+i,name,artist,play,users from res;
     `.lfm.chart set res;
-    `.lfm.chartDate set 09:30+1+.z.D;
+    x:"";
   ];
-  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;string key z;y]);          / pass message back to server
+  if[0=count res;:()];                                                                          / no return for empty chart
+  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]);          / pass message back to server
  };
 
 / bitcoin

--- a/worker.q
+++ b/worker.q
@@ -53,16 +53,16 @@ dictlkup:{
   :neg[.z.w](`worker;`music;"Hey ",x,", ",res);                                                 / pass message back to server
  };
 
-.lfm.getChart:{[x;y]
+.lfm.getChart:{[x;y;z]
   // logic to determine if request should be made or return cache
-  msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value y];                                  / make request to last fm
+  msg:.lfm.httpGet["user.gettoptracks&period=7day"]'[value z];                                  / make request to last fm
   res:raze{[x;y]
     :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from (5&count x)#x:x[`toptracks]`track;
-  }'[msg;key y];
+  }'[msg;key z];
   res:0!5#`playcount xdesc select sum playcount,users by name,artist from res;
   res:select no:1+i,name,artist,plays:playcount,users from res;
   `:lfm_chart set res;
-  :neg[.z.w](`worker;`music;"The current chart is:\n","\n"sv"  ",/:"\n"vs .Q.s res);            / pass message back to server
+  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;string key z;y]);          / pass message back to server
  };
 
 / bitcoin

--- a/worker.q
+++ b/worker.q
@@ -55,18 +55,23 @@ dictlkup:{
 
 .lfm.getChart:{[x;y;z]
   res:@[get;`.lfm.chart;()];
-  if[(x~"update")or 0=count res;                                                                / if called from cron update results after 9.30am
-    msg:.lfm.httpGet["user.gettoptracks&period=7day&limit=5"]'[value z];                         / make request to last fm
+  if[(""~x`u)or 0=count res;                                                                    / if called from cron update results after 9.30am
+    msg:.lfm.httpGet["user.gettoptracks&period=7day&limit=5"]'[value z];                        / make request to last fm
     res:raze{[x;y]
       :select name,{x`name}'[artist],"J"$playcount,users:5#enlist y from x[`toptracks]`track;
     }'[msg;key z];
-    res:0!5#`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
-    res:select no:1+i,name,artist,scrobbles,users from res;
     `.lfm.chart set res;
-    if[x~"update";x:""];
   ];
   if[0=count res;:()];                                                                          / no return for empty chart
-  :neg[.z.w](`worker;`music;$[x~"";"T";"Hey ",x,", t"],"he current chart is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]);          / pass message back to server
+  e:"";
+  if[not any ``update=x`f;
+    res:select from res where users=x`f;
+    e:raze"for ",string[x`c]," ";
+  ];
+  res:0!`scrobbles xdesc select scrobbles:sum playcount,users by name,artist from res;
+  res:select no:1+i,name,artist,scrobbles,users from res;
+  res:5#res;
+  :neg[.z.w](`worker;`music;$[""~x`u;"T";"Hey ",x[`u],", t"],"he current chart ",e,"is:\n","\n"sv"  ",/:"\n"vs ssr/[.Q.s res;("\" ";"\""),string key z;("   ";""),y]); / pass message back to server
  };
 
 / bitcoin


### PR DESCRIPTION
Addition of chart and refactoring of last fm bot code. Users can now request a chart and filter by user:
```
\ml chart
\ml chart&user
\ml user&chart
```
The chart is only updated once per day but can be forced updated.

Additional edits:
* lfm bot requests are now send as `(function;user;requested user;additional params)`.
* lfm bot code moved to `lfm_worker.q`.
* `atproc` applied to messages received from worker process.

This should be squashed if merged.