### PR TITLE
Last FM refactor

### DIFF
--- a/bots.q
+++ b/bots.q
@@ -9,11 +9,12 @@ syny:{[x;y;z] neg[wh](`syny;trim "c"$3_x);}
 rhym:{[x;y;z] neg[wh](`rhym;trim "c"$3_x);}
 strm:{[x;y;z] if[""~trim "c"$3_x;:rc[;y;0]"\033[GSTREAMBOT: usage \\tv {show or movie name}"];neg[wh](`strm;trim "c"$3_x);}
 mulo:{[m;h;u]                                                                                   / [message;handle;user]
+  `:bb set(m;h;u);
   if[()~key`:lfm_key;:rc[;h;0]"\033[Gmusic lookup not enabled"];                                / return error if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_m;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
-      "* usage='\\ml <USERNAME>{&<FILTER>}{&<PERIOD>}' OR '\\ml chart{&<USER>}{&<FILTER>}'";
+      "* usage='\\ml <USERNAME>{&<FILTER>{&<PERIOD>}}' OR '\\ml chart{&<USER>}{&<FILTER>}'";
       "* Filters: tracks, artists, albums\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users: ",$[0=count k:key .lfm.cache;"()";atproc", "sv "@",'string k]);
     :rc[;h;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;     / display available options
@@ -22,18 +23,18 @@ mulo:{[m;h;u]                                                                   
     `:lfm_cache set$[0=count uname:(1+msg?"=")_msg;u _.lfm.cache;.lfm.cache,enlist[u]!enlist uname]; / update cache
     :rc[;h;0]"\033[GUpdated username";
   ];
-  p:`$msg:("***";"&")0:msg;
-  if[`chart in p;                                                                               / chart has been requested
+  msg:("SSS";"&")0:msg;
+  if[`chart in msg;                                                                               / chart has been requested
     rc[;h;0]"\033[GSending Chart Request";
-    p _:p?`chart;
-    ad:p 1;
-    if[not(r:p[0])in key .lfm.cache;r:`;ad:p 0];                                                / return error if user is unavailable
+    msg _:msg?`chart;
+    ad:msg 1;
+    if[not(r:msg 0)in key .lfm.cache;r:`;ad:msg 0];                                             / return error if user is unavailable
     :getchart[u;r;ad];
   ];
   msg:@[;`filter`period;lower]`name`filter`period!msg;
-  if[not(`$msg`name)in key .lfm.cache;:rc[;h;0]"\033[Guser not available"];                     / return error if requested user is unavailable
+  if[not msg[`name]in key .lfm.cache;:rc[;h;0]"\033[Guser not available"];                      / return error if requested user is unavailable
   rc[;h;0]"\033[GSending Request";
-  neg[wh](`.lfm.request;u;enlist[`$msg`name]#.lfm.cache;msg);                                   / send request to worker process
+  neg[wh](`.lfm.request;u;enlist[msg`name]#.lfm.cache;msg);                                     / send request to worker process
  };
 getchart:{[u;r;ad]                                                                              / [user;request;additional] get chart for given parameters
   if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`)];                 / update cron
@@ -42,7 +43,8 @@ getchart:{[u;r;ad]                                                              
     .lfm.cache:@[get;`:lfm_cache;()!()];                                                        / load cache of lastfm usernames
     if[0=count .lfm.cache;:()];                                                                 / exit if no users are cached
   ];
-  neg[wh](`.lfm.request;u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!("chart";ad));                / send request
+  `:aa set(u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!(`chart;ad));
+  neg[wh](`.lfm.request;u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!(`chart;ad));                 / send request
  };
 updatechart:getchart[`;`];
 updatechart`;                                                                                   / initialise cron job

--- a/bots.q
+++ b/bots.q
@@ -27,8 +27,7 @@ mulo:{[m;h;u]                                                                   
     rc[;h;0]"\033[GSending Chart Request";
     p _:p?`chart;
     ad:`;
-    if[`artists in p;ad:`artists;p _:p?`artists];
-    if[not(r:p 0)in`,key .lfm.cache;:rc[;h;0]"\033[Guser not available"];                       / return error if user is unavailable
+    if[not r:p[0]in key .lfm.cache;r:`;ad:p 0];                                                 / return error if user is unavailable
     :getchart[u;r;ad];
   ];
   msg:@[;`filter`period;lower]`name`filter`period!msg;
@@ -37,16 +36,17 @@ mulo:{[m;h;u]                                                                   
   neg[wh](`.lfm.request;u;enlist[`$msg`name]#.lfm.cache;msg);                                   / send request to worker process
  };
 getchart:{[u;r;ad]                                                                              / [user;request;additional] get chart for given parameters
-  if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`update)];           / update cron
+  if[not`updatechart in cron`action;`cron insert(09:30+1+.z.D;`updatechart;`)];                 / update cron
   if[null u;                                                                                    / need to check for skipped steps if run by cron
     if[()~key`:lfm_key;:()];                                                                    / exit if unenabled
     .lfm.cache:@[get;`:lfm_cache;()!()];                                                        / load cache of lastfm usernames
     if[0=count .lfm.cache;:()];                                                                 / exit if no users are cached
   ];
+  `:aa set (u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!("chart";ad));
   neg[wh](`.lfm.request;u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!("chart";ad));                / send request
  };
 updatechart:getchart[`;`];
-updatechart`update;                                                                             / initialise cron job
+updatechart`;                                                                                   / initialise cron job
 
 btcp:{[x;y;z]
  a:" " vs trim"c"$3_x;

--- a/bots.q
+++ b/bots.q
@@ -13,7 +13,7 @@ mulo:{[m;h;u]                                                                   
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_m;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
-      "* usage='\\ml <USERNAME>(&<FILTER>&<PERIOD>)' OR '\\ml chart'";
+      "* usage='\\ml <USERNAME>{&<FILTER>}{&<PERIOD>}' OR '\\ml chart{&<USER>}{&artists}'";
       "* Filters: tracks, artists, chart\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users: ",$[0=count k:key .lfm.cache;"()";atproc", "sv "@",'string k]);
     :rc[;h;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;     / display available options

--- a/bots.q
+++ b/bots.q
@@ -1,6 +1,6 @@
 labels,:("\\ne";"\\ml";"\\bc";"\\df";"\\st";"\\an";"\\sn";"\\ud";"\\wk";"\\rh";"\\tv")!("news";"music";"bitcoin";"define";"stock";"antonym";"synonym";"urbandictionary";"wikipedia";"rhymes";"streaming lookup");
 
-news:{[x;y;z]rc[;y;0]"\033[GGetting news";neg[wh](`getheadline;uct string z);}
+news:{[x;y;z] rc[;y;0]"\033[GGetting news";neg[wh](`getheadline;uct string z);}
 defn:{[x;y;z] neg[wh](`dictlkup;trim "c"$3_x);}
 urbd:{[x;y;z] neg[wh](`udlkup;trim "c"$3_x);}
 wiki:{[x;y;z] neg[wh](`wikilkup;trim "c"$3_x);}
@@ -13,8 +13,8 @@ mulo:{[m;h;u]                                                                   
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_m;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
-      "* usage='\\ml <USERNAME>{&<FILTER>}{&<PERIOD>}' OR '\\ml chart{&<USER>}{&artists}'";
-      "* Filters: tracks, artists, chart\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
+      "* usage='\\ml <USERNAME>{&<FILTER>}{&<PERIOD>}' OR '\\ml chart{&<USER>}{&<FILTER>}'";
+      "* Filters: tracks, artists, albums\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users: ",$[0=count k:key .lfm.cache;"()";atproc", "sv "@",'string k]);
     :rc[;h;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;     / display available options
   ];
@@ -26,8 +26,8 @@ mulo:{[m;h;u]                                                                   
   if[`chart in p;                                                                               / chart has been requested
     rc[;h;0]"\033[GSending Chart Request";
     p _:p?`chart;
-    ad:`;
-    if[not r:p[0]in key .lfm.cache;r:`;ad:p 0];                                                 / return error if user is unavailable
+    ad:p 1;
+    if[not(r:p[0])in key .lfm.cache;r:`;ad:p 0];                                                / return error if user is unavailable
     :getchart[u;r;ad];
   ];
   msg:@[;`filter`period;lower]`name`filter`period!msg;
@@ -42,7 +42,6 @@ getchart:{[u;r;ad]                                                              
     .lfm.cache:@[get;`:lfm_cache;()!()];                                                        / load cache of lastfm usernames
     if[0=count .lfm.cache;:()];                                                                 / exit if no users are cached
   ];
-  `:aa set (u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!("chart";ad));
   neg[wh](`.lfm.request;u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!("chart";ad));                / send request
  };
 updatechart:getchart[`;`];

--- a/bots.q
+++ b/bots.q
@@ -9,12 +9,11 @@ syny:{[x;y;z] neg[wh](`syny;trim "c"$3_x);}
 rhym:{[x;y;z] neg[wh](`rhym;trim "c"$3_x);}
 strm:{[x;y;z] if[""~trim "c"$3_x;:rc[;y;0]"\033[GSTREAMBOT: usage \\tv {show or movie name}"];neg[wh](`strm;trim "c"$3_x);}
 mulo:{[m;h;u]                                                                                   / [message;handle;user]
-  `:bb set(m;h;u);
   if[()~key`:lfm_key;:rc[;h;0]"\033[Gmusic lookup not enabled"];                                / return error if unenabled
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_m;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
-      "* usage='\\ml <USERNAME>{&<FILTER>{&<PERIOD>}}' OR '\\ml chart{&<USER>}{&<FILTER>}'";
+      "* usage='\\ml <USER>{&<FILTER>{&<PERIOD>}}' OR '\\ml chart{&<USER>}{&<FILTER>}' OR '\\ml <USER>&scrobbles'";
       "* Filters: tracks, artists, albums\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users: ",$[0=count k:key .lfm.cache;"()";atproc", "sv "@",'string k]);
     :rc[;h;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;     / display available options
@@ -24,12 +23,17 @@ mulo:{[m;h;u]                                                                   
     :rc[;h;0]"\033[GUpdated username";
   ];
   msg:("SSS";"&")0:msg;
-  if[`chart in msg;                                                                               / chart has been requested
+  if[`chart in msg;                                                                             / chart has been requested
     rc[;h;0]"\033[GSending Chart Request";
     msg _:msg?`chart;
     ad:msg 1;
     if[not(r:msg 0)in key .lfm.cache;r:`;ad:msg 0];                                             / return error if user is unavailable
     :getchart[u;r;ad];
+  ];
+  if[`scrobbles in msg;                                                                         / return number of scrobbles for a user
+    msg _:msg?`scrobbles;
+    if[not msg[0]in key .lfm.cache;:rc[;h;0]"\033[Guser not available"];                        / return error if requested user is unavailable
+    neg[wh](`.lfm.request;u;enlist[msg 0]#.lfm.cache;enlist[`filter]!enlist`scrobbles);
   ];
   msg:@[;`filter`period;lower]`name`filter`period!msg;
   if[not msg[`name]in key .lfm.cache;:rc[;h;0]"\033[Guser not available"];                      / return error if requested user is unavailable
@@ -43,7 +47,6 @@ getchart:{[u;r;ad]                                                              
     .lfm.cache:@[get;`:lfm_cache;()!()];                                                        / load cache of lastfm usernames
     if[0=count .lfm.cache;:()];                                                                 / exit if no users are cached
   ];
-  `:aa set(u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!(`chart;ad));
   neg[wh](`.lfm.request;u;$[r=`;(::);((),r)#].lfm.cache;`filter`c!(`chart;ad));                 / send request
  };
 updatechart:getchart[`;`];

--- a/bots.q
+++ b/bots.q
@@ -13,7 +13,8 @@ mulo:{[m;h;u]                                                                   
   .lfm.cache:@[get;`:lfm_cache;()!()];                                                          / load cache of lastfm usernames
   if[0=count msg:trim"c"$3_m;                                                                   / return help message if no input is provided
     options:("* enter 'user=<LFM_NAME>' to update lastfm username, leave blank to unset";
-      "* usage='\\ml <USER>{&<FILTER>{&<PERIOD>}}' OR '\\ml chart{&<USER>}{&<FILTER>}' OR '\\ml <USER>&scrobbles'";
+      "* usage='\\ml <USER>{&<FILTER>{&<PERIOD>}}' OR '\\ml chart{&<USER>}{&<FILTER>}' OR '\\ml {<USER>&}scrobbles'";
+      "  {}=optional parameters";
       "* Filters: tracks, artists, albums\n* Periods: overall, 7day, 1month, 3month, 6month, 12month";
       "  users: ",$[0=count k:key .lfm.cache;"()";atproc", "sv "@",'string k]);
     :rc[;h;0]"\033[Gmusic lookup from lastfm enabled, available options:\n","\n"sv options;     / display available options

--- a/bots.q
+++ b/bots.q
@@ -32,8 +32,9 @@ mulo:{[m;h;u]                                                                   
   ];
   if[`scrobbles in msg;                                                                         / return number of scrobbles for a user
     msg _:msg?`scrobbles;
-    if[not msg[0]in key .lfm.cache;:rc[;h;0]"\033[Guser not available"];                        / return error if requested user is unavailable
-    neg[wh](`.lfm.request;u;enlist[msg 0]#.lfm.cache;enlist[`filter]!enlist`scrobbles);
+    r:.lfm.cache;
+    if[msg[0]in key r;r:((),msg 0)#r];                                                          / return error if requested user is unavailable
+    :neg[wh](`.lfm.request;u;r;enlist[`filter]!enlist`scrobbles);
   ];
   msg:@[;`filter`period;lower]`name`filter`period!msg;
   if[not msg[`name]in key .lfm.cache;:rc[;h;0]"\033[Guser not available"];                      / return error if requested user is unavailable

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -5,59 +5,60 @@
 .lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
 
 / variables required to build up messages
-.lfm.filters.np:("tracks";"artists")!`toptracks`topartists;                                     / allowed filters
-.lfm.periods:("overall";"7day";"1month";"3month";"6month";"12month")!("overall";"7 day";"1 month";"3 month";"6 month";"12 month"); / allowed periods
+.lfm.filters:`tracks`artists`albums;                                                            / allowed filters
+.lfm.periods:`overall`7day`1month`3month`6month`12month!("overall";"7 day";"1 month";"3 month";"6 month";"12 month"); / allowed periods
 .lfm.funcs:(`artist`playcount`album,`$"@attr")!(first;"J"$;first;{"true"~last x});              / column functions
-.lfm.cols:`topartists`toptracks`recenttracks`tracks_ch`artists_ch`albums_ch!(`name`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr");`name`artist`playcount;`name`playcount;`name`artist`playcount); / columns for parsing requests
+.lfm.cols:`artists`tracks`albums`recenttracks!(`name`playcount;`name`artist`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr")); / columns for parsing requests
 
 .lfm.request:{[u;l;msg]                                                                         / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
-  if["chart"~msg`filter;:.lfm.getChart[u;l;msg]];
+  if[`chart~msg`filter;:.lfm.getChart[u;l;msg]];
   res:.lfm.parseMethod[u;l;msg];                                                                / parse inputs
   :neg[.z.w](`worker;`music;raze"Hey @",string[u],", @",string[first key l],res);               / pass message back to server
  };
 
 .lfm.parseMethod:{[u;l;msg]                                                                     / [user;lfm name;msg] parse request methos
-  if[not msg[`period]in key .lfm.periods;msg[`period]:"7day"];                                  / set default period
-  a:$[msg[`filter]in key .lfm.filters.np;                                                       / determine request params
-    (1;"user.gettop",msg[`filter],"&period=",msg`period;.lfm.filters.np msg`filter);
-    (1;"user.getrecenttracks";`recenttracks)
+  if[not msg[`period]in key .lfm.periods;msg[`period]:`7day];                                   / set default period
+  a:$[msg[`filter]in .lfm.filters;                                                              / determine request params
+    ("user.gettop",string[msg`filter],"&period=",string msg`period;msg`filter);
+    ("user.getrecenttracks";`recenttracks)
   ];
-  res:first raze .lfm.httpLimit[a 0;a 1;;;.lfm.cols[a 2]#.lfm.funcs]'[key l;get l];             / http request
-  :.lfm.parse[a 2][.lfm.periods msg`period;res];                                                / parse results
+  res:first raze .lfm.httpLimit[1;a 0;;;.lfm.cols[a 1]#.lfm.funcs]'[key l;get l];               / http request
+  :.lfm.parse[a 1][.lfm.periods msg`period;res];                                                / parse results
  };
 
 .lfm.parse.recenttracks:{[p;m]                                                                  / [period;message] parser for recent tracks
   r:$[m`$"@attr";" is listening";" last listened"];                                             / determine if song is currently playing
   :r," to '",m[`name],"' by ",m[`artist]," from ",m`album;                                      / format message
  };
-.lfm.parse.toptracks:{[p;m]                                                                     / [period;message] parser for top tracks
+.lfm.parse.tracks:{[p;m]                                                                        / [period;message] parser for top tracks
   :"'s ",p," top track is '",m[`name],"' by ",m[`artist]," with ",string[m`playcount]," scrobbles"; / format message
  };
-.lfm.parse.topartists:{[p;m]                                                                    / [period;message] parser for top artists
+.lfm.parse.artists:{[p;m]                                                                       / [period;message] parser for top artists
   :"'s ",p," top artist is ",m[`name]," with ",string[m`playcount]," scrobbles";                / format message
+ };
+.lfm.parse.albums:{[p;m]                                                                        / [period;message] parser for top albums
+  :"'s ",p," top album is '",m[`name],"' by ",m[`artist]," with ",string[m`playcount]," scrobbles"; / format message
  };
 
 .lfm.httpLimit:{[p;r;u;l;c]                                                                     / [limit;request;user;lfm name;cols+funcs]
-  q:$[p=0W;"";"&limit=",string p];                                                              / limit results if necessary
-  res:{[q;r;l;c]                                                                                / loop over pages to get all results
-    if[0=count d:first raze .lfm.httpGet[r,q;l];:()];                                           / return empty list if no results
-    :({@/[;x;y]x#z}.(key c;get c))'[d];                                                         / apply column functions
-  }[q;r;l;c];
+  r,:$[p=0W;"";"&limit=",string p];                                                             / limit results if necessary
+  if[0=count d:first raze .lfm.httpGet[r;l];:()];                                               / return empty list if no results
+  res:{@/[;x;y]x#z}[key c;get c]'[d];                                                           / apply column functions
   if[98=type res;:update users:u from res];                                                     / add username
   :res;
  };
 
-.lfm.filters.chart:`tracks`artists`albums!`tracks_ch`artists_ch`albums_ch;                      / allowed filters
-.lfm.chart.tracks:{select scrobbles:sum playcount,distinct users by track:name,artist from @[x;`name;trim 50$]}; / get counts by tracks
-.lfm.chart.artists:{select scrobbles:playcount,distinct users by artist:name from x};           / get counts by artists
-.lfm.chart.albums:{select scrobbles:sum playcount,distinct users by album:name,artist from @[x;`name;trim 50$]}; / get counts by albums
 .lfm.getChart:{[u;l;msg]
-  if[not msg[`c]in key .lfm.filters.chart;msg[`c]:`tracks];                                     / default to tracks
+  if[not msg[`c]in .lfm.filters;msg[`c]:`tracks];                                               / default to tracks
   e:$[1=count k:key l;("for @",string[first k]," ";5);("";0W)];                                 / name of requested user
   lbl:-1_string msg`c;
-  res:raze .lfm.httpLimit[e 1;"user.getweekly",lbl,"chart";;;.lfm.cols[.lfm.filters.chart msg`c]#.lfm.funcs]'[key l;get l]; / http request
+  res:raze .lfm.httpLimit[e 1;"user.getweekly",lbl,"chart";;;.lfm.cols[msg`c]#.lfm.funcs]'[key l;get l]; / http request
   if[0=count res;:()];                                                                          / no return for empty chart
   res:update("@",'string users)from res;                                                        / allow colours
   res:`no xcols update no:fills?[differ scrobbles;1+i;0N]from 5 sublist`scrobbles xdesc 0!.lfm.chart[msg`c]res;   / collate results and return top 5
   :neg[.z.w](`worker;`music;ssr[;"\n";"\n  "]$[`~u;"T";"Hey @",string[u],", t"],"he current ",lbl," chart ",e[0],"is:\n",.Q.s@[res;cols[res]where any"C "=\:exec t from meta res;`$]); / pass message back to server
  };
+
+.lfm.chart.tracks:{select scrobbles:sum playcount,distinct users by track:name,artist from @[x;`name;trim 50$]}; / get counts by tracks
+.lfm.chart.artists:{select scrobbles:playcount,distinct users by artist:name from x};           / get counts by artists
+.lfm.chart.albums:{select scrobbles:sum playcount,distinct users by album:name,artist from @[x;`name;trim 50$]}; / get counts by albums

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -41,7 +41,7 @@
   ];
   res:.lfm.http[a 2][1;a 0;;;.lfm.cols[a 1]#.lfm.funcs]'[key l;get l];                          / http request
   if[`table=a 2;res:first raze res];
-  :.lfm.parse[a 1][string first key l;.lfm.periods msg`period;res];                             / parse results
+  :.lfm.parse[a 1]["@",string first key l;.lfm.periods msg`period;res];                         / parse results
  };
 
 .lfm.getChart:{[u;l;msg]
@@ -61,16 +61,16 @@
  };
 .lfm.parse.recenttracks:{[l;p;m]                                                                / [req user;period;message] parser for recent tracks
   r:$[m`$"@attr";" is listening";" last listened"];                                             / determine if song is currently playing
-  :"@",l,r," to '",m[`name],"' by ",m[`artist]," from ",m`album;                                / format message
+  :l,r," to '",m[`name],"' by ",m[`artist]," from ",m`album;                                    / format message
  };
 .lfm.parse.tracks:{[l;p;m]                                                                      / [req user;period;message] parser for top tracks
-  :"@",l,"'s ",p," top track is '",m[`name],"' by ",m[`artist]," with ",string[m`playcount]," scrobbles"; / format message
+  :l,"'s ",p," top track is '",m[`name],"' by ",m[`artist]," with ",string[m`playcount]," scrobbles"; / format message
  };
 .lfm.parse.artists:{[l;p;m]                                                                     / [req user;period;message] parser for top artists
-  :"@",l,"'s ",p," top artist is ",m[`name]," with ",string[m`playcount]," scrobbles";          / format message
+  :l,"'s ",p," top artist is ",m[`name]," with ",string[m`playcount]," scrobbles";              / format message
  };
 .lfm.parse.albums:{[l;p;m]                                                                      / [req user;period;message] parser for top albums
-  :"@",l,"'s ",p," top album is '",m[`name],"' by ",m[`artist]," with ",string[m`playcount]," scrobbles"; / format message
+  :l,"'s ",p," top album is '",m[`name],"' by ",m[`artist]," with ",string[m`playcount]," scrobbles"; / format message
  };
 .lfm.parse.getInfo:{[l;p;m]                                                                     / [req user;period;message] get info for a user
   if[1=count m;:"@",l," has ",string[first m`playcount]," scrobbles"];

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -74,7 +74,7 @@
  };
 .lfm.parse.getInfo:{[l;p;m]                                                                     / [req user;period;message] get info for a user
   if[1=count m;:"@",l," has ",string[first m`playcount]," scrobbles"];
-  :"the current scrobbles are:",.lfm.parse.table{@[;`users;enlist']x xdesc x xcol y}[`scrobbles;m];
+  :"the current scrobble counts are:",.lfm.parse.table{@[;`users;enlist']x xdesc x xcol y}[`scrobbles;m];
  };
 
 .lfm.chart.tracks:{select scrobbles:sum playcount,distinct users by track:name,artist from @[x;`name;trim 50$]}; / get counts by tracks

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -12,8 +12,7 @@
 
 .lfm.httpLimit:{[p;r;c;u;l]                                                                     / [limit;request;cols+funcs;user;lfm name]
   r,:$[p=0W;"";"&limit=",string p];                                                             / limit results if necessary
-  m:(`$"@attr")in key d:raze .lfm.httpGet[r;l];                                                 / determine method
-  d:$[m:(`$"@attr")in key d;first;(::)]d;
+  d:$[m:(`$"@attr")in key d:raze .lfm.httpGet[r;l];first;(::)]d;                                / determine method
   if[0=count d;:()];                                                                            / return empty list if no results
   res:{@/[;x;y]x#z}[key c;get c]'[$[m;(::);enlist]d];                                           / apply column functions
   :update users:u from res;                                                                     / add username and return

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -5,10 +5,10 @@
 .lfm.httpGet:{.j.k .Q.hg`$"http://ws.audioscrobbler.com/2.0/?format=json&api_key=",.lfm.key,"&method=",x,"&user=",y};
 
 / variables required to build up messages
-.lfm.filters:("tracks";"artists")!`toptracks`topartists;                                        / allowed filters
+.lfm.filters.np:("tracks";"artists")!`toptracks`topartists;                                     / allowed filters
 .lfm.periods:("overall";"7day";"1month";"3month";"6month";"12month")!("overall";"7 day";"1 month";"3 month";"6 month";"12 month"); / allowed periods
 .lfm.funcs:(`artist`playcount`album,`$"@attr")!(first;"J"$;first;{"true"~last x});              / column functions
-.lfm.cols:`topartists`toptracks`recenttracks`chart!(`name`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr");`name`artist`playcount); / columns for parsing requests
+.lfm.cols:`topartists`toptracks`recenttracks`tracks_ch`artists_ch`albums_ch!(`name`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr");`name`artist`playcount;`name`playcount;`name`artist`playcount); / columns for parsing requests
 
 .lfm.request:{[u;l;msg]                                                                         / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
   if["chart"~msg`filter;:.lfm.getChart[u;l;msg]];
@@ -18,8 +18,8 @@
 
 .lfm.parseMethod:{[u;l;msg]                                                                     / [user;lfm name;msg] parse request methos
   if[not msg[`period]in key .lfm.periods;msg[`period]:"7day"];                                  / set default period
-  a:$[msg[`filter]in key .lfm.filters;                                                          / determine request params
-    (1;"user.gettop",msg[`filter],"&period=",msg`period;.lfm.filters msg`filter);
+  a:$[msg[`filter]in key .lfm.filters.np;                                                       / determine request params
+    (1;"user.gettop",msg[`filter],"&period=",msg`period;.lfm.filters.np msg`filter);
     (1;"user.getrecenttracks";`recenttracks)
   ];
   res:first raze .lfm.httpWrap[a 0;a 1;;;.lfm.cols[a 2]#.lfm.funcs]'[key l;get l];              / http request
@@ -39,30 +39,27 @@
 
 .lfm.httpWrap:{[p;r;u;l;c]                                                                      / [limit;request;user;lfm name;cols+funcs]
   q:$[p=0W;("";1b);("&limit=",string p;0b)];                                                    / limit results if necessary
-  res:first{[q;x;y;z]                                                                           / loop over pages to get all tracks
+  res:first{[q;p;x;y;z]                                                                         / loop over pages to get all results
+    if[p<=count z 0;:@[z;0;sublist[p]]];                                                        / exit early if limit is reached, ensures limit is definitely kept
     r:.lfm.httpGet[x,q[0],"&page=",string z 1;y];                                               / api request
     if[0=count l:first raze r;:z];                                                              / exit early if no results
     z[0]:distinct z[0],{@/[;x;y]x#z}[z 2;z 3]'[l];                                              / update results
     :@[z;1;+;q 1];                                                                              / increment page number
-  }[q;r;l]/[(();1;key c;get c)];
+  }[q;p;r;l]/[(();1;key c;get c)];
   if[98=type res;:update users:u from res];                                                     / add username
   :res;
  };
 
+.lfm.filters.chart:`tracks`artists`albums!`tracks_ch`artists_ch`albums_ch;                      / allowed filtersi
+.lfm.chart.artists:{`artist`scrobbles xcol x};                                                  / get counts by artists
+.lfm.chart.tracks:{`name`artist`scrobbles xcol @[x;`name;trim 50$]};                            / get counts by tracks
+.lfm.chart.albums:{`album`scrobbles xcol x};                                                    / get counts by albums
 .lfm.getChart:{[u;l;msg]
-  res:@[get;`.lfm.chart;()];                                                                    / get cache chart
-  if[(`update~msg`c)or 0=count res;                                                             / if called from cron update results
-    res:raze .lfm.httpWrap[0W;"user.gettoptracks&period=7day";;;.lfm.cols[`chart]#.lfm.funcs]'[key l;get l]; / http request
-    `.lfm.chart set res;                                                                        / cache results
-  ];
-  res:select from res where users in key l;                                                     / filter by user
+  if[not msg[`c]in key .lfm.filters.chart;msg[`c]:`tracks];                                     / default to tracks
+  res:`playcount xdesc raze .lfm.httpWrap[5;"user.getweekly",(-1_string msg`c),"chart";;;.lfm.cols[.lfm.filters.chart msg`c]#.lfm.funcs]'[key l;get l]; / http request
   if[0=count res;:()];                                                                          / no return for empty chart
   e:$[1=count k:key l;"for @",string[first k]," ";""];                                          / name of requested user
-  res:@[;`name;trim 50$]update("@",'string users)from res;                                                        / allow colours
-  res:0!`scrobbles xdesc$[`artists=msg`c;
-    select scrobbles:sum playcount,distinct users by artist from res;
-    select scrobbles:sum playcount,distinct users by name,artist from res
-  ];
-  res:(`no,cols[res]inter`name`artist`scrobbles`users)#update no:1+i from 5#res;                / return top 5
+  res:update("@",'string users)from res;                                                        / allow colours
+  res:`no xcols update no:1+i from 5 sublist .lfm.chart[msg`c]res;                              / return top 5
   :neg[.z.w](`worker;`music;ssr[;"\n";"\n  "]$[`~u;"T";"Hey @",string[u],", t"],"he current chart ",e,"is:\n",.Q.s@[res;cols[res]where any"C "=\:exec t from meta res;`$]); / pass message back to server
  };

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -50,7 +50,7 @@
   lbl:-1_string msg`c;
   res:raze .lfm.http.table[e 1;"user.getweekly",lbl,"chart";;;.lfm.cols[msg`c]#.lfm.funcs]'[key l;get l]; / http request
   if[0=count res;:()];                                                                          / no return for empty chart
-  res:.lfm.parse.table 5 sublist`scrobbles xdesc .lfm.chart[msg`c]res;
+  res:.lfm.parse.table 5 sublist`scrobbles xdesc .lfm.chart[msg`c]@[res;`name;trim 50$];        / trim wide columns
   :neg[.z.w](`worker;`music;$[`~u;"T";"Hey @",string[u],", t"],"he current ",lbl," chart ",e[0],"is:",res); / pass message back to server
  };
 
@@ -77,6 +77,6 @@
   :"the current scrobble counts are:",.lfm.parse.table{@[;`users;enlist']x xdesc x xcol y}[`scrobbles;m];
  };
 
-.lfm.chart.tracks:{select scrobbles:sum playcount,distinct users by track:name,artist from @[x;`name;trim 50$]}; / get counts by tracks
-.lfm.chart.artists:{select scrobbles:playcount,distinct users by artist:name from x};           / get counts by artists
-.lfm.chart.albums:{select scrobbles:sum playcount,distinct users by album:name,artist from @[x;`name;trim 50$]}; / get counts by albums
+.lfm.chart.tracks:{select scrobbles:sum playcount,distinct users by track:name,artist from x};  / get counts by tracks
+.lfm.chart.artists:{select scrobbles:sum playcount,distinct users by artist:name from x};       / get counts by artists
+.lfm.chart.albums:{select scrobbles:sum playcount,distinct users by album:name,artist from x};  / get counts by albums

--- a/lfm_worker.q
+++ b/lfm_worker.q
@@ -8,10 +8,25 @@
 .lfm.filters:`tracks`artists`albums;                                                            / allowed filters
 .lfm.periods:`overall`7day`1month`3month`6month`12month!("overall";"7 day";"1 month";"3 month";"6 month";"12 month"); / allowed periods
 .lfm.funcs:(`artist`playcount`album,`$"@attr")!(first;"J"$;first;{"true"~last x});              / column functions
-.lfm.cols:`artists`tracks`albums`recenttracks!(`name`playcount;`name`artist`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr")); / columns for parsing requests
+.lfm.cols:`artists`tracks`albums`recenttracks`getInfo!(`name`playcount;`name`artist`playcount;`name`artist`playcount;(`name`artist`playcount`album,`$"@attr");(),`playcount); / columns for parsing requests
+
+.lfm.http.table:{[p;r;u;l;c]                                                                    / [limit;request;user;lfm name;cols+funcs]
+  r,:$[p=0W;"";"&limit=",string p];                                                             / limit results if necessary
+  if[0=count d:first raze .lfm.httpGet[r;l];:()];                                               / return empty list if no results
+  res:{@/[;x;y]x#z}[key c;get c]'[d];                                                           / apply column functions
+  if[98=type res;:update users:u from res];                                              / add username
+  :res;
+ };
+
+.lfm.http.dict:{[p;r;u;l;c]                                                                     / [limit;request;user;lfm name;cols+funcs]
+  if[0=count d:raze .lfm.httpGet[r;l];:()];                                                     / return empty list if no results
+  res:{@/[;x;y]x#z}[key c;get c;d];                                                             / apply column functions
+  if[type[res]in 98 99h;:update users:u from res];                                              / add username
+  :res;
+ };
 
 .lfm.request:{[u;l;msg]                                                                         / [user;lfm name;msg] return users now playing track, mentioning the user who made the request
-  if[`chart~msg`filter;:.lfm.getChart[u;l;msg]];
+  if[`chart=msg`filter;:.lfm.getChart[u;l;msg]];                                                / use chart specific method
   res:.lfm.parseMethod[u;l;msg];                                                                / parse inputs
   :neg[.z.w](`worker;`music;raze"Hey @",string[u],", @",string[first key l],res);               / pass message back to server
  };
@@ -19,11 +34,24 @@
 .lfm.parseMethod:{[u;l;msg]                                                                     / [user;lfm name;msg] parse request methos
   if[not msg[`period]in key .lfm.periods;msg[`period]:`7day];                                   / set default period
   a:$[msg[`filter]in .lfm.filters;                                                              / determine request params
-    ("user.gettop",string[msg`filter],"&period=",string msg`period;msg`filter);
-    ("user.getrecenttracks";`recenttracks)
+    ("user.gettop",string[msg`filter],"&period=",string msg`period;msg`filter;`table);
+    `scrobbles=msg`filter;
+      ("user.getinfo";`getInfo;`dict);
+      ("user.getrecenttracks";`recenttracks;`table)
   ];
-  res:first raze .lfm.httpLimit[1;a 0;;;.lfm.cols[a 1]#.lfm.funcs]'[key l;get l];               / http request
+  res:first raze .lfm.http[a 2][1;a 0;;;.lfm.cols[a 1]#.lfm.funcs]'[key l;get l];                     / http request
   :.lfm.parse[a 1][.lfm.periods msg`period;res];                                                / parse results
+ };
+
+.lfm.getChart:{[u;l;msg]
+  if[not msg[`c]in .lfm.filters;msg[`c]:`tracks];                                               / default to tracks
+  e:$[1=count k:key l;("for @",string[first k]," ";5);("";0W)];                                 / name of requested user
+  lbl:-1_string msg`c;
+  res:raze .lfm.http.table[e 1;"user.getweekly",lbl,"chart";;;.lfm.cols[msg`c]#.lfm.funcs]'[key l;get l]; / http request
+  if[0=count res;:()];                                                                          / no return for empty chart
+  res:update("@",'string users)from res;                                                        / allow colours
+  res:`no xcols update no:fills?[differ scrobbles;1+i;0N]from 5 sublist`scrobbles xdesc 0!.lfm.chart[msg`c]res;   / collate results and return top 5
+  :neg[.z.w](`worker;`music;ssr[;"\n";"\n  "]$[`~u;"T";"Hey @",string[u],", t"],"he current ",lbl," chart ",e[0],"is:\n",.Q.s@[res;cols[res]where any"C "=\:exec t from meta res;`$]); / pass message back to server
  };
 
 .lfm.parse.recenttracks:{[p;m]                                                                  / [period;message] parser for recent tracks
@@ -39,24 +67,8 @@
 .lfm.parse.albums:{[p;m]                                                                        / [period;message] parser for top albums
   :"'s ",p," top album is '",m[`name],"' by ",m[`artist]," with ",string[m`playcount]," scrobbles"; / format message
  };
-
-.lfm.httpLimit:{[p;r;u;l;c]                                                                     / [limit;request;user;lfm name;cols+funcs]
-  r,:$[p=0W;"";"&limit=",string p];                                                             / limit results if necessary
-  if[0=count d:first raze .lfm.httpGet[r;l];:()];                                               / return empty list if no results
-  res:{@/[;x;y]x#z}[key c;get c]'[d];                                                           / apply column functions
-  if[98=type res;:update users:u from res];                                                     / add username
-  :res;
- };
-
-.lfm.getChart:{[u;l;msg]
-  if[not msg[`c]in .lfm.filters;msg[`c]:`tracks];                                               / default to tracks
-  e:$[1=count k:key l;("for @",string[first k]," ";5);("";0W)];                                 / name of requested user
-  lbl:-1_string msg`c;
-  res:raze .lfm.httpLimit[e 1;"user.getweekly",lbl,"chart";;;.lfm.cols[msg`c]#.lfm.funcs]'[key l;get l]; / http request
-  if[0=count res;:()];                                                                          / no return for empty chart
-  res:update("@",'string users)from res;                                                        / allow colours
-  res:`no xcols update no:fills?[differ scrobbles;1+i;0N]from 5 sublist`scrobbles xdesc 0!.lfm.chart[msg`c]res;   / collate results and return top 5
-  :neg[.z.w](`worker;`music;ssr[;"\n";"\n  "]$[`~u;"T";"Hey @",string[u],", t"],"he current ",lbl," chart ",e[0],"is:\n",.Q.s@[res;cols[res]where any"C "=\:exec t from meta res;`$]); / pass message back to server
+.lfm.parse.getInfo:{[p;m]
+  :" has ",string[m]," scrobbles";
  };
 
 .lfm.chart.tracks:{select scrobbles:sum playcount,distinct users by track:name,artist from @[x;`name;trim 50$]}; / get counts by tracks

--- a/worker.q
+++ b/worker.q
@@ -3,6 +3,7 @@
 
 /cron
 cron:([]time:"p"$();action:`$();args:());
+qid:{$[99h=type x;.Q.id'[key x]!get x;.Q.id x]};                                                / purge bad chars
 
 .z.ts:{pi:exec i from cron where time<.z.P;if[count pi;r:exec action,args from cron where i in pi;delete from `cron where i in pi;({value[x]. (),y}.)'[flip value r]];};
 
@@ -95,7 +96,7 @@ topcheck:30
 shamethresh:70
 toptab:([]pid:"i"%();user:0#`;mem:0#0f;cmd:0#`;time:0#.z.P)
 shamed:([]time:0#.z.P;user:`)
-gettop:{toptab,:select from 
+gettop:{toptab,:select from
   (update time:.z.P from `pid`user`mem`cmd xcol
     ("IS       F S";enlist",")0:","sv'{x where 0<count@'x}@'" "vs'6_system"top -bn1 -o \"%MEM\"") where mem>x;
   shame:(key exec avg mem by user from toptab where time>.z.P-"v"$y+5)except raze exec user from shamed where time>.z.P-"v"$900;


### PR DESCRIPTION
Extensive updates to last fm code that serve to both simplify and expand functionality.
* chart logic simplified by leveraging inbuilt api weekly chart requests.
* charts and top requests now have exactly the same filters, allow the same column logic to be used for both.
* addition of album filter.
* can now request total number of scrobbles for a user or all users.
* help message now includes info on new methods.