### PR TITLE
rework main process to reduce reliance on system commands

### DIFF
--- a/chatter.q
+++ b/chatter.q
@@ -1,3 +1,4 @@
+if[not system"p";system"p 0W";-1 "Set main process port to :",string system"p"]; /if started without port, pick a random available one and output it
 init:{[x]
   wh::first key .z.W;               /worker has opened handle, first handle in .z.W will be worker
   system@'"l ",/:("kg";"chat";"func";"levenshtein";"bots";"pts";"plot";"connect4"),\:".q";

--- a/chatter.q
+++ b/chatter.q
@@ -1,12 +1,7 @@
-workeron:1b;
-if[workeron;`SSL_VERIFY_SERVER setenv "no";system"q worker.q -p ",string[wp:{$[x~r:@[system;"lsof -i :",string x;x];x;x+1i]}/[system"p"]];system"sleep 0.5";wh:hopen "j"$wp];
-\l kg.q
-\l chat.q
-\l func.q
-\d .c4
-\l connect4.q
-\d .
-\l levenshtein.q
-\l bots.q
-\l pts.q
-\l plot.q
+init:{[x]
+  wh::first key .z.W;               /worker has opened handle, first handle in .z.W will be worker
+  system@'"l ",/:("kg";"chat";"func";"levenshtein";"bots";"pts";"plot";"connect4"),\:".q";
+ }
+p:string system"p";                 /get main proc port for worker to callback
+system"q worker.q ",p," -p 0W";     /start worker on random available port
+/after this, main proc will wait for init to be called by worker

--- a/connect4.q
+++ b/connect4.q
@@ -9,7 +9,7 @@
 /       Close if one player quits or server exits (ADD QUIT RECORD TO LB TABLE)
 / DONE  Maintain on-disk leaderboard? (in case of quit, award win to non-quitter) ([] p1:`$();p2:`$();w:`$();m:`int$();q:`boolean$())
 /       Add "testing" mode where results aren't recorded (auto-enable in case of both players having same username)
-
+\d .c4
 
 players:()!()                                                   / dict for handle!username
 curplayer:0                                                     / player 1 starts
@@ -107,3 +107,5 @@ lb:{get `:lb}
 
 / generate actual leaderboard
 top:{`wins xdesc select wins:count i by player:w from lb[]}
+
+\d .

--- a/worker.q
+++ b/worker.q
@@ -1,3 +1,5 @@
+mh:hopen "J"$.z.x 0                                 /open handle to main process using 1st parameter as port
+neg[mh](`init;`);                                   /call init functionon main process to set wh & load code
 
 .z.pw:{[u;p]"b"$not count .z.W};
 \t 1000


### PR DESCRIPTION
Re-written main process to remove the need to search for a free port & sleep etc., making use of KDB's ability to select a random free port with `-p 0W` and a callback to the main chat process from the worker once it's initialised

Also removed the switch for enabling/disabling worker - at this point I think worker is pretty integral, and already if you set this to `0b` loading would fail - I think when loading `bots.q`